### PR TITLE
update matrix version to 9.0.0rc1

### DIFF
--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["9.0.0-beta1", "8.17.4", "7.17.28"]
+        version: ["9.0.0-rc1", "8.17.4", "7.17.28"]
         env: [docker, eck]
     steps:
       - name: Checkout code
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["9.0.0-beta1", "8.17.4", "7.17.28"]
+        version: ["9.0.0-rc1", "8.17.4", "7.17.28"]
         env: [docker, eck]
     env:
       ROR_ES_VERSION: "latest"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Elasticsearch version used in end-to-end test workflows from "9.0.0-beta1" to "9.0.0-rc1".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->