### PR TITLE
fix flaky user settings test

### DIFF
--- a/e2e-tests/cypress/support/page-objects/SecuritySettings.ts
+++ b/e2e-tests/cypress/support/page-objects/SecuritySettings.ts
@@ -31,6 +31,24 @@ export class SecuritySettings {
     return cy.get('#readonlyrestIframe').its('0.contentWindow').should('exist');
   };
 
+  static waitForIframeContent(selector = '.euiTabs', timeout = 15000) {
+    cy.get('#readonlyrestIframe').should('be.visible');
+
+    return cy.window().then({ timeout }, win => {
+      return new Cypress.Promise(resolve => {
+        const checkIframe = () => {
+          const iframe: HTMLIFrameElement = win.document.querySelector('#readonlyrestIframe');
+          if (iframe && iframe.contentDocument && iframe.contentDocument.querySelector(selector)) {
+            resolve();
+          } else {
+            setTimeout(checkIframe, 100);
+          }
+        };
+        checkIframe();
+      });
+    });
+  }
+
   static checkActiveTab(tab: string) {
     SecuritySettings.getIframeBody().findByRole('tab', { name: tab, selected: true }).should('be.visible');
   }

--- a/e2e-tests/cypress/support/page-objects/UserSettings.ts
+++ b/e2e-tests/cypress/support/page-objects/UserSettings.ts
@@ -17,6 +17,11 @@ export class UserSettings {
   static openViaMenuIcon() {
     cy.log('Open via menu icon');
     cy.get('[data-testid="user-settings-icon"]').click();
+
+    // First ensure the iframe is visible in the DOM
+    cy.get('#readonlyrestIframe').should('be.visible');
+
+    SecuritySettings.waitForIframeContent();
   }
 
   static changeUserSettingsValue(userSettings: string, value: string) {

--- a/e2e-tests/cypress/support/page-objects/UserSettings.ts
+++ b/e2e-tests/cypress/support/page-objects/UserSettings.ts
@@ -18,9 +18,6 @@ export class UserSettings {
     cy.log('Open via menu icon');
     cy.get('[data-testid="user-settings-icon"]').click();
 
-    // First ensure the iframe is visible in the DOM
-    cy.get('#readonlyrestIframe').should('be.visible');
-
     SecuritySettings.waitForIframeContent();
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved reliability of end-to-end tests by adding explicit waiting for iframe content to fully load before proceeding with further steps in security and user settings scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->