### PR TITLE
[RORDEV-1445] Trigger tests for ECK 2.x and 3.x

### DIFF
--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ["9.0.1", "8.18.1", "7.17.28"]
-        env: [docker, eck-2x, eck-3x]
+        env: [docker, eck-2.16.1, eck-3.0.0]
     env:
       ROR_ES_VERSION: "latest"
       ROR_KBN_VERSION: "latest"

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ["9.0.1", "8.18.1", "7.17.28"]
-        env: [docker, eck]
+        env: [docker, eck-2.16.1, eck-3.0.0]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ["9.0.1", "8.18.1", "7.17.28"]
-        env: [docker, eck]
+        env: [docker, eck-2x, eck-3x]
     env:
       ROR_ES_VERSION: "latest"
       ROR_KBN_VERSION: "latest"

--- a/run-env-and-tests.sh
+++ b/run-env-and-tests.sh
@@ -25,7 +25,7 @@ while [[ $# -gt 0 ]]; do
           OPTIONAL_ECK_ARG="--eck ${2#eck-}"
           ;;
         *)
-          echo "Error: --env: Only "docker" and 'eck' are available environments"
+          echo "Error: --env: Only 'docker' and 'eck-x.y.z' patterns are supported"
           show_help
           ;;
       esac

--- a/run-env-and-tests.sh
+++ b/run-env-and-tests.sh
@@ -73,13 +73,6 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [ "$ENV_NAME" == "eck-ror" ]; then
-  if [ -z "$ECK_VERSION" ]; then
-    echo "Error: --eck is required when env is eck"
-    show_help
-  fi
-fi
-
 handle_error() {
   ./environments/"$ENV_NAME"/print-logs.sh
 }

--- a/run-env-and-tests.sh
+++ b/run-env-and-tests.sh
@@ -63,7 +63,7 @@ while [[ $# -gt 0 ]]; do
     fi
     ;;
   --dev)
-    MODE="--dev"
+    OPTIONAL_MODE="--dev"
     shift
     ;;
   *)
@@ -104,5 +104,5 @@ echo -e "
 
 echo -e "E2E TESTS\n"
 
-time ./environments/$ENV_NAME/start.sh --es "$ELK_VERSION" --kbn "$ELK_VERSION" $OPTIONAL_ECK_ARG $OPTIONAL_ROR_ES_ARG $OPTIONAL_ROR_KBN_ARG $MODE
+time ./environments/$ENV_NAME/start.sh --es "$ELK_VERSION" --kbn "$ELK_VERSION" $OPTIONAL_ECK_ARG $OPTIONAL_ROR_ES_ARG $OPTIONAL_ROR_KBN_ARG $OPTIONAL_MODE
 time ./e2e-tests/run-tests.sh "$ELK_VERSION"

--- a/run-env-and-tests.sh
+++ b/run-env-and-tests.sh
@@ -21,7 +21,7 @@ while [[ $# -gt 0 ]]; do
           ENV_NAME="elk-ror"
           ;;
         eck-*)
-          ENV_NAME="$2-ror"
+          ENV_NAME="eck-ror"
           OPTIONAL_ECK_ARG="--eck ${2#eck-}"
           ;;
         *)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated end-to-end test environments to include specific ECK versions (2.16.1 and 3.0.0) for improved test coverage.
	- Enhanced script usability by supporting explicit ECK version selection and updating usage instructions accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->