### PR TITLE
update matrix to 8.18.2 and 9.0.2

### DIFF
--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["9.0.1", "8.18.2", "7.17.28"]
+        version: ["9.0.2", "8.18.2", "7.17.28"]
         env: [docker, eck-2.16.1, eck-3.0.0]
     steps:
       - name: Checkout code
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["9.0.1", "8.18.2", "7.17.28"]
+        version: ["9.0.2", "8.18.2", "7.17.28"]
         env: [docker, eck-2.16.1, eck-3.0.0]
     env:
       ROR_ES_VERSION: "latest"

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["9.0.1", "8.18.1", "7.17.28"]
+        version: ["9.0.1", "8.18.2", "7.17.28"]
         env: [docker, eck-2.16.1, eck-3.0.0]
     steps:
       - name: Checkout code

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["9.0.1", "8.18.1", "7.17.28"]
+        version: ["9.0.1", "8.18.2", "7.17.28"]
         env: [docker, eck-2.16.1, eck-3.0.0]
     env:
       ROR_ES_VERSION: "latest"

--- a/environments/common/images/node-apm-app/Dockerfile
+++ b/environments/common/images/node-apm-app/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 
 RUN apt-get update && \
-    apt-get install -y libc6-amd64-cross vim curl npm && \
+    apt-get install -y --fix-missing libc6-amd64-cross vim curl npm && \
     ln -s /usr/x86_64-linux-gnu/lib64/ /lib64 && \
     mkdir -p /example-app
 

--- a/environments/common/images/node-apm-app/Dockerfile
+++ b/environments/common/images/node-apm-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 RUN apt-get update && \
     apt-get install -y --fix-missing libc6-amd64-cross vim curl npm && \

--- a/environments/common/images/node-apm-app/Dockerfile
+++ b/environments/common/images/node-apm-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.10
+FROM ubuntu:24.04
 
 RUN apt-get update && \
     apt-get install -y libc6-amd64-cross vim curl npm && \

--- a/environments/common/images/node-apm-app/Dockerfile
+++ b/environments/common/images/node-apm-app/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y --fix-missing\
     curl \
     libc6-amd64-cross && \
     ln -s /usr/x86_64-linux-gnu/lib64/ /lib64
+RUN mkdir -p /example-app
 
 COPY ./app.js /example-app
 WORKDIR /example-app

--- a/environments/common/images/node-apm-app/Dockerfile
+++ b/environments/common/images/node-apm-app/Dockerfile
@@ -1,21 +1,14 @@
-FROM ubuntu:22.04
+FROM node:20
 
-RUN apt-get update && \
-    apt-get install -y --fix-missing libc6-amd64-cross vim curl npm && \
-    ln -s /usr/x86_64-linux-gnu/lib64/ /lib64 && \
-    mkdir -p /example-app
+RUN apt-get update && apt-get install -y --fix-missing\
+    vim \
+    curl \
+    libc6-amd64-cross && \
+    ln -s /usr/x86_64-linux-gnu/lib64/ /lib64
 
 COPY ./app.js /example-app
-
-RUN cd /example-app && \
-    npm install elastic-apm-node && \
-    npm install express
-
-ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/lib64:/usr/x86_64-linux-gnu/lib"
-
 WORKDIR /example-app
 
 EXPOSE 3000
 
-# Define the entrypoint to execute the application
 ENTRYPOINT ["node", "app.js"]

--- a/environments/common/images/node-apm-app/Dockerfile
+++ b/environments/common/images/node-apm-app/Dockerfile
@@ -1,15 +1,21 @@
-FROM node:20
+FROM ubuntu:24.10
 
-RUN apt-get update && apt-get install -y --fix-missing\
-    vim \
-    curl \
-    libc6-amd64-cross && \
-    ln -s /usr/x86_64-linux-gnu/lib64/ /lib64
-RUN mkdir -p /example-app
+RUN apt-get update && \
+    apt-get install -y libc6-amd64-cross vim curl npm && \
+    ln -s /usr/x86_64-linux-gnu/lib64/ /lib64 && \
+    mkdir -p /example-app
 
 COPY ./app.js /example-app
+
+RUN cd /example-app && \
+    npm install elastic-apm-node && \
+    npm install express
+
+ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/lib64:/usr/x86_64-linux-gnu/lib"
+
 WORKDIR /example-app
 
 EXPOSE 3000
 
+# Define the entrypoint to execute the application
 ENTRYPOINT ["node", "app.js"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated end-to-end test workflows to use Elasticsearch versions 9.0.2 and 8.18.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->