### PR TITLE
remove patching flags

### DIFF
--- a/environments/eck-ror/kind-cluster/ror/es.yml
+++ b/environments/eck-ror/kind-cluster/ror/es.yml
@@ -17,9 +17,6 @@ spec:
                 runAsUser: 0
                 runAsGroup: 0
               env:
-                # For ROR_ES_VERSION >= 1.64.0
-                - name: I_UNDERSTAND_AND_ACCEPT_ES_PATCHING
-                  value: "yes"
                 # For ROR_ES_VERSION < 1.64.0
                 - name: I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING
                   value: "yes"

--- a/environments/elk-ror/images/es/Dockerfile
+++ b/environments/elk-ror/images/es/Dockerfile
@@ -14,8 +14,6 @@ COPY certs/elasticsearch.crt /usr/share/elasticsearch/config/elasticsearch.crt
 COPY certs/elasticsearch.csr /usr/share/elasticsearch/config/elasticsearch.csr
 COPY certs/elasticsearch.key /usr/share/elasticsearch/config/elasticsearch.key
 
-# For ROR_ES_VERSION >= 1.64.0
-ENV I_UNDERSTAND_AND_ACCEPT_ES_PATCHING yes
 # For ROR_ES_VERSION < 1.64.0
 ENV I_UNDERSTAND_IMPLICATION_OF_ES_PATCHING yes
 USER root


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the environment variable related to Elasticsearch patching acceptance for newer ROR_ES_VERSION (>= 1.64.0). No impact on existing functionality for earlier versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->