### PR TITLE
update matrix to 9.1.0

### DIFF
--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["9.0.4", "8.18.4", "7.17.29"]
+        version: ["9.1.0", "8.18.4", "7.17.29"]
         env: [docker, eck-2.16.1, eck-3.1.0]
     steps:
       - name: Checkout code
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["9.0.4", "8.18.4", "7.17.29"]
+        version: ["9.1.0", "8.18.4", "7.17.29"]
         env: [docker, eck-2.16.1, eck-3.1.0]
     env:
       ROR_ES_VERSION: "latest"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Elasticsearch version used in automated end-to-end tests from 9.0.4 to 9.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->