### PR TITLE
[RORDEV-1964] Remove free type username impersonate test

### DIFF
--- a/e2e-tests/cypress/e2e/Impersonate.cy.ts
+++ b/e2e-tests/cypress/e2e/Impersonate.cy.ts
@@ -100,11 +100,6 @@ describe('impersonate', () => {
     Impersonate.saveEditMockUsers();
     Impersonate.assertUser(2, 1, 'kibana', ['group3']);
 
-    cy.log('should free impersonate user check');
-    Impersonate.freeTypeImpersonateUser('new_user');
-    Impersonate.finishImpersonation();
-    Impersonate.verifyFinishedImpersonation();
-
     cy.log('should impersonate localUser');
     Impersonate.open();
     Impersonate.impersonateUserFromTheList(3, 2, 'new_user');

--- a/e2e-tests/cypress/support/page-objects/Impersonate.ts
+++ b/e2e-tests/cypress/support/page-objects/Impersonate.ts
@@ -139,21 +139,6 @@ export class Impersonate {
     SecuritySettings.getIframeBody().find('[data-testid=confirm-button]').click();
   }
 
-  static openImpersonateDialog() {
-    cy.log('Open impersonate dialog');
-    SecuritySettings.getIframeBody().findByTestId('impersonate-button').click();
-  }
-
-  static freeTypeImpersonateUser(username) {
-    cy.log('Free type impersonate user');
-    Impersonate.openImpersonateDialog();
-    SecuritySettings.getIframeBody().find('[data-testid=confirm-button]').as('confirm-button');
-    cy.get('@confirm-button').should('be.disabled');
-    SecuritySettings.getIframeBody().find('[data-testid=name-field]').type(username);
-    cy.get('@confirm-button').click();
-    Impersonate.verifyImpersonation(username);
-  }
-
   static impersonateUserFromTheList(index: number, rowIndex: number, username: string) {
     cy.log('impersonation user from the list');
     Impersonate.getServiceByIndex(index).as('service');


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed unused test helper methods and simplified the impersonation testing workflow. The changes streamline test execution by eliminating intermediate verification and cleanup steps in the test sequence, reducing test redundancy and improving overall maintainability of the testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->