### PR TITLE
[RORDEV-1993] Cleanup after releasing ROR 1.69.1

### DIFF
--- a/.github/upload-videos/action.yml
+++ b/.github/upload-videos/action.yml
@@ -9,7 +9,7 @@ inputs:
   bucket:
     description: 'S3 bucket name'
     required: true
-    default: 'readonlyrest-data'
+    default: 'beshu'
 
 runs:
   using: 'composite'

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["9.3.2", "9.2.7", "8.19.13", "7.17.29"]
+        version: ["9.3.3", "9.2.8", "8.19.14", "7.17.29"]
         env: [docker, eck-2.16.1, eck-3.1.0]
     steps:
       - name: Checkout code
@@ -101,7 +101,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [ "9.3.2", "9.2.7", "8.19.13", "7.17.29" ]
+        version: [ "9.3.3", "9.2.8", "8.19.14", "7.17.29" ]
         env: [docker, eck-2.16.1, eck-3.1.0]
     env:
       ROR_ES_VERSION: "latest"

--- a/e2e-tests/cypress/e2e/Search-apps.cy.ts
+++ b/e2e-tests/cypress/e2e/Search-apps.cy.ts
@@ -20,13 +20,11 @@ describe('Search apps', () => {
     SearchApps.verifyAppsInSearchResults(['Stack Management']); // only Stack Management app should be visible, because if we hide all apps, there is only loading indicator visible in a Kibana UI
     Home.verifyIfCatalogueEmpty();
 
-    //FIXME: there is a problem with integrations visiblility when xpack.security.enabled: true
-
-    // SearchApps.searchApp('aws');
-    // SearchApps.noResultsFound();
-    //
-    // SearchApps.searchApp('type:integration');
-    // SearchApps.noResultsFound();
+    SearchApps.searchApp('aws');
+    SearchApps.noResultsFound();
+    
+    SearchApps.searchApp('type:integration');
+    SearchApps.noResultsFound();
 
     SearchApps.searchApp('readonly');
     SearchApps.noResultsFound();

--- a/e2e-tests/cypress/fixtures/defaultSettings.yaml
+++ b/e2e-tests/cypress/fixtures/defaultSettings.yaml
@@ -27,7 +27,7 @@ readonlyrest:
     - name: "Kibana service account - user/pass"
       verbosity: error
       auth_key: kibana:kibana
-      kibana_access: unrestricted
+      
     - name: 'APM'
       type: allow
       auth_key: apm:test

--- a/e2e-tests/cypress/fixtures/hiddenAllAppsSettings.yaml
+++ b/e2e-tests/cypress/fixtures/hiddenAllAppsSettings.yaml
@@ -3,7 +3,7 @@ readonlyrest:
     - name: "Kibana service account - user/pass"
       verbosity: error
       auth_key: kibana:kibana
-      kibana_access: unrestricted
+      
     - name: ADMIN_GRP
       groups: [admins_group]
       kibana_hide_apps: [ "Enterprise Search", "Observability", "Elasticsearch", "Analytics", "Management"]

--- a/e2e-tests/cypress/fixtures/hiddenHomePageSettings.yaml
+++ b/e2e-tests/cypress/fixtures/hiddenHomePageSettings.yaml
@@ -4,7 +4,7 @@ readonlyrest:
     - name: "Kibana service account - user/pass"
       verbosity: error
       auth_key: kibana:kibana
-      kibana_access: unrestricted
+      
     - name: ADMIN_GRP
       groups: [admins_group]
       kibana_hide_apps: [ "Home"]

--- a/e2e-tests/cypress/fixtures/hiddenSpaceManagementSettings.yaml
+++ b/e2e-tests/cypress/fixtures/hiddenSpaceManagementSettings.yaml
@@ -3,7 +3,7 @@ readonlyrest:
     - name: 'Kibana service account - user/pass'
       verbosity: error
       auth_key: kibana:kibana
-      kibana_access: unrestricted
+      
     - name: ADMIN_GRP
       groups: [admins_group]
       kibana_hide_apps: ['Management|Stack Management']

--- a/e2e-tests/cypress/fixtures/reportingSettings.yaml
+++ b/e2e-tests/cypress/fixtures/reportingSettings.yaml
@@ -26,7 +26,7 @@ readonlyrest:
     - name: "Kibana service account - user/pass"
       verbosity: error
       auth_key: kibana:kibana
-      kibana_access: unrestricted
+      
     # <-- related to ECK environment -->
     - name: "Kibana service account - token"
       verbosity: error

--- a/e2e-tests/cypress/fixtures/roSettings.yaml
+++ b/e2e-tests/cypress/fixtures/roSettings.yaml
@@ -26,7 +26,7 @@ readonlyrest:
     - name: "Kibana service account - user/pass"
       verbosity: error
       auth_key: kibana:kibana
-      kibana_access: unrestricted
+      
     # <-- related to ECK environment -->
     - name: "Kibana service account - token"
       verbosity: error

--- a/e2e-tests/cypress/fixtures/roStrictSettings.yaml
+++ b/e2e-tests/cypress/fixtures/roStrictSettings.yaml
@@ -26,7 +26,7 @@ readonlyrest:
     - name: "Kibana service account - user/pass"
       verbosity: error
       auth_key: kibana:kibana
-      kibana_access: unrestricted
+      
     # <-- related to ECK environment -->
     - name: "Kibana service account - token"
       verbosity: error

--- a/e2e-tests/cypress/fixtures/settingsWithReadonlyRestKbn.yml
+++ b/e2e-tests/cypress/fixtures/settingsWithReadonlyRestKbn.yml
@@ -26,7 +26,7 @@ readonlyrest:
     - name: "Kibana service account - user/pass"
       verbosity: error
       auth_key: kibana:kibana
-      kibana_access: unrestricted
+      
     - name: PERSONAL_GRP
       groups: [Personal]
       kibana:

--- a/environments/eck-ror/kind-cluster/ror/base/ror-initial-config.yml
+++ b/environments/eck-ror/kind-cluster/ror/base/ror-initial-config.yml
@@ -39,7 +39,7 @@ data:
         - name: "Kibana service account - user/pass"
           verbosity: error
           auth_key: kibana:kibana
-          kibana_access: unrestricted
+          
         - name: "PROBE"
           verbosity: error
           auth_key: "elastic-internal-probe:${INTERNAL_PROBE_PASS}"

--- a/environments/elk-ror/conf/es/readonlyrest.yml
+++ b/environments/elk-ror/conf/es/readonlyrest.yml
@@ -29,7 +29,6 @@ readonlyrest:
     - name: "Kibana service account - user/pass"
       verbosity: error
       auth_key: kibana:kibana
-      kibana_access: unrestricted
 
     - name: "APM"
       type: allow


### PR DESCRIPTION
In ROR 1.69.1 the bug from 1.69.0 was fixed - there is no need to add `kibana.access: unrestricted` explicitly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed explicit Kibana access value for the Kibana service account across multiple test fixtures and deployment configs.
  * Activated end-to-end search tests to run searches for "aws" and "type:integration" and assert no results.
  * Updated E2E test matrix to use newer Elasticsearch/Kibana version combinations.
* **Chores**
  * Changed default bucket name for the video upload action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->