### PR TITLE
[RORDEV-2013] ECK 3.3.0 support

### DIFF
--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ["9.3.3", "9.2.8", "8.19.14", "7.17.29"]
-        env: [docker, eck-2.16.1, eck-3.1.0]
+        env: [docker, eck-2.16.1, eck-3.2.0]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -80,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ["9.3.0", "9.2.0", "9.1.0", "9.0.0", "8.19.0", "8.18.0", "8.17.0", "8.16.0", "8.15.0", "8.14.0", "8.13.0", "8.12.0", "8.11.0", "8.10.1", "8.9.0", "8.8.0", "8.7.0", "8.6.0", "8.5.0", "8.4.0", "8.3.0", "8.2.0", "8.1.0", "8.0.0", "7.17.0", "7.16.0", "7.15.0", "7.14.0", "7.13.0", "7.12.0", "7.11.2", "7.10.0", "7.9.0"]
-        env: [docker, eck-3.1.0]
+        env: [docker, eck-3.2.0]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -123,7 +123,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "9.3.3", "9.2.8", "8.19.14", "7.17.29" ]
-        env: [docker, eck-2.16.1, eck-3.1.0]
+        env: [docker, eck-2.16.1, eck-3.2.0]
     env:
       ROR_ES_VERSION: "latest"
       ROR_KBN_VERSION: "latest"

--- a/.github/workflows/trigger-e2e-tests.yml
+++ b/.github/workflows/trigger-e2e-tests.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ["9.3.3", "9.2.8", "8.19.14", "7.17.29"]
-        env: [docker, eck-2.16.1, eck-3.2.0]
+        env: [docker, eck-2.16.1, eck-3.3.0]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -80,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ["9.3.0", "9.2.0", "9.1.0", "9.0.0", "8.19.0", "8.18.0", "8.17.0", "8.16.0", "8.15.0", "8.14.0", "8.13.0", "8.12.0", "8.11.0", "8.10.1", "8.9.0", "8.8.0", "8.7.0", "8.6.0", "8.5.0", "8.4.0", "8.3.0", "8.2.0", "8.1.0", "8.0.0", "7.17.0", "7.16.0", "7.15.0", "7.14.0", "7.13.0", "7.12.0", "7.11.2", "7.10.0", "7.9.0"]
-        env: [docker, eck-3.2.0]
+        env: [docker, eck-3.3.0]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -123,7 +123,7 @@ jobs:
       fail-fast: false
       matrix:
         version: [ "9.3.3", "9.2.8", "8.19.14", "7.17.29" ]
-        env: [docker, eck-2.16.1, eck-3.2.0]
+        env: [docker, eck-2.16.1, eck-3.3.0]
     env:
       ROR_ES_VERSION: "latest"
       ROR_KBN_VERSION: "latest"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment configuration to use ECK 3.3.0 across end-to-end and bootstrap testing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->