### PR TITLE
[RORDEV-2043] stop overwriting stock ES log4j2.properties — use a ROR drop-in instead

### DIFF
--- a/environments/eck-ror/kind-cluster/ror/base/es.yml
+++ b/environments/eck-ror/kind-cluster/ror/base/es.yml
@@ -42,7 +42,7 @@ spec:
                   mountPath: /usr/share/elasticsearch/config/readonlyrest.yml
                   subPath: readonlyrest.yml
                 - name: config-log4j2
-                  mountPath: /usr/share/elasticsearch/config/log4j2.properties
+                  mountPath: /usr/share/elasticsearch/config/ror/log4j2.properties
                   subPath: log4j2.properties
 
           volumes:

--- a/environments/eck-ror/kind-cluster/ror/base/log4j2.properties.yml
+++ b/environments/eck-ror/kind-cluster/ror/base/log4j2.properties.yml
@@ -6,7 +6,7 @@ data:
     # config dir). This declares only the extra loggers (no appenders / rootLogger / status), so the
     # stock config stays intact -- including ES's entitlement-logger suppression, which keeps the
     # benign x-pack-security "Not entitled" file-watcher warnings quiet.
-    logger.ror.name=tech.beshu.ror.accesscontrol
+    logger.ror.name=tech.beshu.ror
     logger.ror.level=info
 kind: ConfigMap
 metadata:

--- a/environments/eck-ror/kind-cluster/ror/base/log4j2.properties.yml
+++ b/environments/eck-ror/kind-cluster/ror/base/log4j2.properties.yml
@@ -1,75 +1,11 @@
 apiVersion: v1
 data:
   log4j2.properties: |
-    status=error
-    
-    logger.action.name=org.elasticsearch.action
-    logger.action.level=info
-    appender.console.type=Console
-    appender.console.name=console
-    appender.console.layout.type=PatternLayout
-    appender.console.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
-    appender.rolling.type=RollingFile
-    appender.rolling.name=rolling
-    appender.rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}.log
-    appender.rolling.layout.type=PatternLayout
-    appender.rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%.10000m%n
-    appender.rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}-%d{yyyy-MM-dd}.log
-    appender.rolling.policies.type=Policies
-    appender.rolling.policies.time.type=TimeBasedTriggeringPolicy
-    appender.rolling.policies.time.interval=1
-    appender.rolling.policies.time.modulate=true
-    rootLogger.level=info
-    rootLogger.appenderRef.console.ref=console
-    rootLogger.appenderRef.rolling.ref=rolling
-    appender.deprecation_rolling.type=RollingFile
-    appender.deprecation_rolling.name=deprecation_rolling
-    appender.deprecation_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation.log
-    appender.deprecation_rolling.layout.type=PatternLayout
-    appender.deprecation_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%.10000m%n
-    appender.deprecation_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation-%i.log.gz
-    appender.deprecation_rolling.policies.type=Policies
-    appender.deprecation_rolling.policies.size.type=SizeBasedTriggeringPolicy
-    appender.deprecation_rolling.policies.size.size=1GB
-    appender.deprecation_rolling.strategy.type=DefaultRolloverStrategy
-    appender.deprecation_rolling.strategy.max=4
-    logger.deprecation.name = org.elasticsearch.deprecation
-    logger.deprecation.level = deprecation
-    logger.deprecation.appenderRef.header_warning.ref = header_warning
-    logger.deprecation.appenderRef.deprecation_rolling.ref=deprecation_rolling
-    logger.deprecation.additivity=false
-    appender.index_search_slowlog_rolling.type=RollingFile
-    appender.index_search_slowlog_rolling.name=index_search_slowlog_rolling
-    appender.index_search_slowlog_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog.log
-    appender.index_search_slowlog_rolling.layout.type=PatternLayout
-    appender.index_search_slowlog_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c] %marker%.10000m%n
-    appender.index_search_slowlog_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog-%d{yyyy-MM-dd}.log
-    appender.index_search_slowlog_rolling.policies.type=Policies
-    appender.index_search_slowlog_rolling.policies.time.type=TimeBasedTriggeringPolicy
-    appender.index_search_slowlog_rolling.policies.time.interval=1
-    appender.index_search_slowlog_rolling.policies.time.modulate=true
-    logger.index_search_slowlog_rolling.name=index.search.slowlog
-    logger.index_search_slowlog_rolling.level=trace
-    logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref=index_search_slowlog_rolling
-    logger.index_search_slowlog_rolling.additivity=false
-    appender.index_indexing_slowlog_rolling.type=RollingFile
-    appender.index_indexing_slowlog_rolling.name=index_indexing_slowlog_rolling
-    appender.index_indexing_slowlog_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog.log
-    appender.index_indexing_slowlog_rolling.layout.type=PatternLayout
-    appender.index_indexing_slowlog_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c] %marker%.10000m%n
-    appender.index_indexing_slowlog_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog-%d{yyyy-MM-dd}.log
-    appender.index_indexing_slowlog_rolling.policies.type=Policies
-    appender.index_indexing_slowlog_rolling.policies.time.type=TimeBasedTriggeringPolicy
-    appender.index_indexing_slowlog_rolling.policies.time.interval=1
-    appender.index_indexing_slowlog_rolling.policies.time.modulate=true
-    logger.index_indexing_slowlog.name=index.indexing.slowlog.index
-    logger.index_indexing_slowlog.level=trace
-    logger.index_indexing_slowlog.appenderRef.index_indexing_slowlog_rolling.ref=index_indexing_slowlog_rolling
-    logger.index_indexing_slowlog.additivity=false
-    
-    appender.header_warning.type = HeaderWarningAppender
-    appender.header_warning.name = header_warning
-  
+    # ROR-specific logging, dropped into config/ror/log4j2.properties and merged with the stock ES
+    # config/log4j2.properties (ES recursively loads every file named "log4j2.properties" under the
+    # config dir). This declares only the extra loggers (no appenders / rootLogger / status), so the
+    # stock config stays intact -- including ES's entitlement-logger suppression, which keeps the
+    # benign x-pack-security "Not entitled" file-watcher warnings quiet.
     logger.ror.name=tech.beshu.ror.accesscontrol
     logger.ror.level=info
 kind: ConfigMap

--- a/environments/elk-ror/conf/es/log4j2.properties
+++ b/environments/elk-ror/conf/es/log4j2.properties
@@ -19,5 +19,5 @@
 # config dir). This declares only the extra loggers (no appenders / rootLogger / status), so the
 # stock config stays intact -- including ES's entitlement-logger suppression, which keeps the
 # benign x-pack-security "Not entitled" file-watcher warnings quiet.
-logger.ror.name=tech.beshu.ror.accesscontrol.blocks.rules.elasticsearch.indices
+logger.ror.name=tech.beshu.ror
 logger.ror.level=info

--- a/environments/elk-ror/conf/es/log4j2.properties
+++ b/environments/elk-ror/conf/es/log4j2.properties
@@ -14,75 +14,10 @@
 #     You should have received a copy of the GNU General Public License
 #     along with ReadonlyREST.  If not, see http://www.gnu.org/licenses/
 #
-#
-status=error
-# log actionPost execution errors for easier debugging
-logger.action.name=org.elasticsearch.action
-logger.action.level=info
-appender.console.type=Console
-appender.console.name=console
-appender.console.layout.type=PatternLayout
-appender.console.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
-appender.rolling.type=RollingFile
-appender.rolling.name=rolling
-appender.rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}.log
-appender.rolling.layout.type=PatternLayout
-appender.rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%.10000m%n
-appender.rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}-%d{yyyy-MM-dd}.log
-appender.rolling.policies.type=Policies
-appender.rolling.policies.time.type=TimeBasedTriggeringPolicy
-appender.rolling.policies.time.interval=1
-appender.rolling.policies.time.modulate=true
-rootLogger.level=info
-rootLogger.appenderRef.console.ref=console
-rootLogger.appenderRef.rolling.ref=rolling
-appender.deprecation_rolling.type=RollingFile
-appender.deprecation_rolling.name=deprecation_rolling
-appender.deprecation_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation.log
-appender.deprecation_rolling.layout.type=PatternLayout
-appender.deprecation_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c{1.}] %marker%.10000m%n
-appender.deprecation_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation-%i.log.gz
-appender.deprecation_rolling.policies.type=Policies
-appender.deprecation_rolling.policies.size.type=SizeBasedTriggeringPolicy
-appender.deprecation_rolling.policies.size.size=1GB
-appender.deprecation_rolling.strategy.type=DefaultRolloverStrategy
-appender.deprecation_rolling.strategy.max=4
-logger.deprecation.name = org.elasticsearch.deprecation
-logger.deprecation.level = deprecation
-logger.deprecation.appenderRef.header_warning.ref = header_warning
-logger.deprecation.appenderRef.deprecation_rolling.ref=deprecation_rolling
-logger.deprecation.additivity=false
-appender.index_search_slowlog_rolling.type=RollingFile
-appender.index_search_slowlog_rolling.name=index_search_slowlog_rolling
-appender.index_search_slowlog_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog.log
-appender.index_search_slowlog_rolling.layout.type=PatternLayout
-appender.index_search_slowlog_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c] %marker%.10000m%n
-appender.index_search_slowlog_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog-%d{yyyy-MM-dd}.log
-appender.index_search_slowlog_rolling.policies.type=Policies
-appender.index_search_slowlog_rolling.policies.time.type=TimeBasedTriggeringPolicy
-appender.index_search_slowlog_rolling.policies.time.interval=1
-appender.index_search_slowlog_rolling.policies.time.modulate=true
-logger.index_search_slowlog_rolling.name=index.search.slowlog
-logger.index_search_slowlog_rolling.level=trace
-logger.index_search_slowlog_rolling.appenderRef.index_search_slowlog_rolling.ref=index_search_slowlog_rolling
-logger.index_search_slowlog_rolling.additivity=false
-appender.index_indexing_slowlog_rolling.type=RollingFile
-appender.index_indexing_slowlog_rolling.name=index_indexing_slowlog_rolling
-appender.index_indexing_slowlog_rolling.fileName=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog.log
-appender.index_indexing_slowlog_rolling.layout.type=PatternLayout
-appender.index_indexing_slowlog_rolling.layout.pattern=[%d{ISO8601}][%-5p][%-25c] %marker%.10000m%n
-appender.index_indexing_slowlog_rolling.filePattern=${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog-%d{yyyy-MM-dd}.log
-appender.index_indexing_slowlog_rolling.policies.type=Policies
-appender.index_indexing_slowlog_rolling.policies.time.type=TimeBasedTriggeringPolicy
-appender.index_indexing_slowlog_rolling.policies.time.interval=1
-appender.index_indexing_slowlog_rolling.policies.time.modulate=true
-logger.index_indexing_slowlog.name=index.indexing.slowlog.index
-logger.index_indexing_slowlog.level=trace
-logger.index_indexing_slowlog.appenderRef.index_indexing_slowlog_rolling.ref=index_indexing_slowlog_rolling
-logger.index_indexing_slowlog.additivity=false
-
-appender.header_warning.type = HeaderWarningAppender
-appender.header_warning.name = header_warning
-
+# ROR-specific logging, dropped into config/ror/log4j2.properties and merged with the stock ES
+# config/log4j2.properties (ES recursively loads every file named "log4j2.properties" under the
+# config dir). This declares only the extra loggers (no appenders / rootLogger / status), so the
+# stock config stays intact -- including ES's entitlement-logger suppression, which keeps the
+# benign x-pack-security "Not entitled" file-watcher warnings quiet.
 logger.ror.name=tech.beshu.ror.accesscontrol.blocks.rules.elasticsearch.indices
 logger.ror.level=info

--- a/environments/elk-ror/images/es/Dockerfile
+++ b/environments/elk-ror/images/es/Dockerfile
@@ -8,7 +8,7 @@ USER elasticsearch
 
 COPY conf/es/readonlyrest.yml /usr/share/elasticsearch/config/readonlyrest.yml
 COPY conf/es/elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml
-COPY conf/es/log4j2.properties /usr/share/elasticsearch/config/log4j2.properties
+COPY conf/es/log4j2.properties /usr/share/elasticsearch/config/ror/log4j2.properties
 COPY certs/ca.crt /usr/share/elasticsearch/config/ca.crt
 COPY certs/elasticsearch.crt /usr/share/elasticsearch/config/elasticsearch.crt
 COPY certs/elasticsearch.csr /usr/share/elasticsearch/config/elasticsearch.csr


### PR DESCRIPTION
ES 8.18+ (Entitlements framework) ships a suppression for the entitlements logger in its stock config/log4j2.properties. Our full-file copy was stale and dropped that suppression, flooding logs with benign "Not entitled" warnings from x-pack's file watcher.

ES's LogConfigurator recursively merges every file named `log4j2.properties` under the config dir, so we can add a drop-in at `config/ror/log4j2.properties` that declares only our extra loggers. The stock file stays untouched — including the entitlement suppression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized ReadonlyREST logging configuration across deployment environments
  * Isolated plugin-specific logging settings from core Elasticsearch configuration
  * Updated configuration file references in deployment manifests and Docker setup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/beshu-tech/readonlyrest-e2e-tests/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->