### PR TITLE
fix webGL problem on macOS and electron on locally run tests

### DIFF
--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint .",
     "lint:fix": "yarn lint -- --fix",
     "open": "./node_modules/.bin/cypress open",
-    "run": "ELECTRON_ENABLE_LOGGING=1 ./node_modules/.bin/cypress run"
+    "run": "ELECTRON_ENABLE_LOGGING=1 ELECTRON_EXTRA_LAUNCH_ARGS='--ignore-gpu-blocklist' ./node_modules/.bin/cypress run"
   },
   "license": "Beshu Limited, All rights reserved",
   "dependencies": {


### PR DESCRIPTION
**Problem:** 

Kibana Maps uses WebGL to render the map. Cypress runs Electron, which has the GPU on its blocklist — so Chromium automatically falls back to SwiftShader (software renderer).

**Fix:** 

`--ignore-gpu-blocklist` — tells Chromium "use the real GPU even though it's on the blocklist". On macOS, Electron can then use Metal with no software renderer involved.