### PR TITLE
[RORDEV-2041] Split e2e workflow into full-matrix and targeted variants; fix ES healthcheck hang

### DIFF
--- a/.github/workflows/all-e2e-tests.yml
+++ b/.github/workflows/all-e2e-tests.yml
@@ -26,9 +26,11 @@ jobs:
         env: [docker, eck-2.16.1, eck-3.4.0]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
       - name: Set up Node.js
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '24.11.0'
       - name: Clean up disk space
@@ -42,7 +44,7 @@ jobs:
       # - Docker image pull failures (e.g., beshultd/kibana-readonlyrest:*-ror-latest not found)
       # These errors are typically temporary and resolve with a simple retry.
       - name: Run E2E tests
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
         with:
           max_attempts: 2
           timeout_minutes: 60
@@ -85,7 +87,9 @@ jobs:
         env: [docker, eck-3.4.0]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
       - name: Clean up disk space
         uses: ./.github/cleanup-disk-space
       - name: Start Docker memory monitor
@@ -97,7 +101,7 @@ jobs:
       # - Docker image pull failures (e.g., beshultd/kibana-readonlyrest:*-ror-latest not found)
       # These errors are typically temporary and resolve with a simple retry.
       - name: Run bootstrap tests
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
         with:
           max_attempts: 3
           timeout_minutes: 30
@@ -132,9 +136,11 @@ jobs:
       MODE: 'dev'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
       - name: Set up Node.js
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '24.11.0'
       - name: Clean up disk space
@@ -148,7 +154,7 @@ jobs:
       # - Docker image pull failures (e.g., beshultd/kibana-readonlyrest:*-ror-latest not found)
       # These errors are typically temporary and resolve with a simple retry.
       - name: Run E2E tests
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
         with:
           max_attempts: 2
           timeout_minutes: 60

--- a/.github/workflows/all-e2e-tests.yml
+++ b/.github/workflows/all-e2e-tests.yml
@@ -1,29 +1,7 @@
 name: End-to-end test workflow
 
 on:
-  workflow_dispatch:
-    inputs:
-      elk_version:
-        description: 'ELK version to test (e.g., 9.4.1)'
-        required: true
-        type: string
-      env:
-        description: 'Environment type (e.g., docker, eck-3.4.0)'
-        required: true
-        type: string
-      ror_es_version:
-        description: 'ReadonlyREST Elasticsearch Version (e.g., 1.69.1)'
-        required: false
-        type: string
-      ror_kbn_version:
-        description: 'ReadonlyREST Kibana Version (e.g., 1.69.1)'
-        required: false
-        type: string
-      mode:
-        description: 'Repository source for ROR plugin docker image (e.g., prod, dev)'
-        required: false
-        default: 'prod'
-        type: string
+  workflow_dispatch: {}
   schedule:
     - cron: '0 0 * * *'
   pull_request:
@@ -37,6 +15,7 @@ jobs:
     name: "🔬 Master E2E Tests"
     if: >
       github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
       github.ref == 'refs/heads/master' ||
       (github.base_ref == 'master' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false))
     runs-on: ubuntu-latest
@@ -94,6 +73,7 @@ jobs:
     name: "🚀 Bootstrap Tests"
     if: >
       github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
       github.ref == 'refs/heads/master' ||
       (github.base_ref == 'master' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false))
     needs: master-e2e-tests
@@ -190,57 +170,3 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-  manual-e2e-tests:
-    name: "🔬 Manually invoked E2E Tests"
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4.4.0
-        with:
-          node-version: '24.11.0'
-
-      - name: Clean up disk space
-        uses: ./.github/cleanup-disk-space
-
-      - name: Start Docker memory monitor
-        uses: ./.github/docker-memory-monitor
-        with:
-          action: start
-
-      - name: Run E2E tests
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 1
-          timeout_minutes: 60
-          retry_wait_seconds: 120
-          command: |
-            PARAMS=(--run e2e --env "$ENV" --elk "$ELK_VERSION")
-            [ -n "$ROR_ES_VERSION" ] && PARAMS+=(--ror-es "$ROR_ES_VERSION")
-            [ -n "$ROR_KBN_VERSION" ] && PARAMS+=(--ror-kbn "$ROR_KBN_VERSION")
-            [ -n "$MODE" ] && PARAMS+=(--mode "$MODE")
-            ./runner.sh "${PARAMS[@]}"
-        env:
-          ROR_ACTIVATION_KEY: ${{ secrets.ROR_KBN_LICENSE }}
-          ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
-          ENV: ${{ github.event.inputs.env }}
-          ELK_VERSION: ${{ github.event.inputs.elk_version }}
-          ROR_ES_VERSION: ${{ github.event.inputs.ror_es_version }}
-          ROR_KBN_VERSION: ${{ github.event.inputs.ror_kbn_version }}
-          MODE: ${{ github.event.inputs.mode }}
-      - name: Stop Docker memory monitor
-        if: always()
-        uses: ./.github/docker-memory-monitor
-        with:
-          action: stop
-      - name: S3 Upload Videos & show logs
-        if: failure()
-        uses: ./.github/upload-videos
-        with:
-          access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          endpoint_url: ${{ secrets.AWS_ENDPOINT_URL }}

--- a/.github/workflows/targeted-e2e-tests.yml
+++ b/.github/workflows/targeted-e2e-tests.yml
@@ -31,10 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4.4.0
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '24.11.0'
 
@@ -47,7 +49,7 @@ jobs:
           action: start
 
       - name: Run E2E tests
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
         with:
           max_attempts: 1
           timeout_minutes: 60

--- a/.github/workflows/targeted-e2e-tests.yml
+++ b/.github/workflows/targeted-e2e-tests.yml
@@ -1,0 +1,82 @@
+name: Targeted E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      elk_version:
+        description: 'ELK version to test (e.g., 9.4.1)'
+        required: true
+        type: string
+      env:
+        description: 'Environment type (e.g., docker, eck-3.4.0)'
+        required: true
+        type: string
+      ror_es_version:
+        description: 'ReadonlyREST Elasticsearch Version (e.g., 1.69.1)'
+        required: false
+        type: string
+      ror_kbn_version:
+        description: 'ReadonlyREST Kibana Version (e.g., 1.69.1)'
+        required: false
+        type: string
+      mode:
+        description: 'Repository source for ROR plugin docker image (e.g., prod, dev)'
+        required: false
+        default: 'prod'
+        type: string
+
+jobs:
+  e2e-tests:
+    name: "🔬 E2E Tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.4.0
+        with:
+          node-version: '24.11.0'
+
+      - name: Clean up disk space
+        uses: ./.github/cleanup-disk-space
+
+      - name: Start Docker memory monitor
+        uses: ./.github/docker-memory-monitor
+        with:
+          action: start
+
+      - name: Run E2E tests
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 1
+          timeout_minutes: 60
+          retry_wait_seconds: 120
+          command: |
+            PARAMS=(--run e2e --env "$ENV" --elk "$ELK_VERSION")
+            [ -n "$ROR_ES_VERSION" ] && PARAMS+=(--ror-es "$ROR_ES_VERSION")
+            [ -n "$ROR_KBN_VERSION" ] && PARAMS+=(--ror-kbn "$ROR_KBN_VERSION")
+            [ -n "$MODE" ] && PARAMS+=(--mode "$MODE")
+            ./runner.sh "${PARAMS[@]}"
+        env:
+          ROR_ACTIVATION_KEY: ${{ secrets.ROR_KBN_LICENSE }}
+          ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
+          ENV: ${{ github.event.inputs.env }}
+          ELK_VERSION: ${{ github.event.inputs.elk_version }}
+          ROR_ES_VERSION: ${{ github.event.inputs.ror_es_version }}
+          ROR_KBN_VERSION: ${{ github.event.inputs.ror_kbn_version }}
+          MODE: ${{ github.event.inputs.mode }}
+
+      - name: Stop Docker memory monitor
+        if: always()
+        uses: ./.github/docker-memory-monitor
+        with:
+          action: stop
+
+      - name: S3 Upload Videos & show logs
+        if: failure()
+        uses: ./.github/upload-videos
+        with:
+          access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          endpoint_url: ${{ secrets.AWS_ENDPOINT_URL }}

--- a/environments/elk-ror/base.docker-compose.yml
+++ b/environments/elk-ror/base.docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - INTERNAL_PROBE_PASS=UNUSED
       - INTERNAL_USR_PASS=UNUSED
     healthcheck:
-      test: ["CMD-SHELL", "curl -fksS --connect-timeout 3 --max-time 5 --retry 2 --retry-connrefused -u kibana:kibana https://127.0.0.1:9200/_cluster/health >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "curl -fksS --connect-timeout 3 --max-time 5 --retry 2 -u kibana:kibana https://127.0.0.1:9200/_cluster/health >/dev/null || exit 1"]
       interval: 10s
       timeout: 60s
       retries: 30


### PR DESCRIPTION
  Replaces trigger-e2e-tests.yml with two focused workflows:
  - all-e2e-tests.yml — runs the full test matrix on schedule, PRs, or manual dispatch (no inputs needed)
  - targeted-e2e-tests.yml — manual dispatch only, accepts specific ELK/ROR version inputs for targeted runs

 Also removes --retry-connrefused from the Elasticsearch container healthcheck, which could cause the curl retry loop to hang when the connection is permanently refused instead of transiently unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved E2E test workflows to allow manual dispatch and extended job execution on manual runs.
  * Added a new targeted, parameterized workflow for running specific E2E scenarios.
  * Simplified test log/video upload configuration for failure reporting.
  * Adjusted local Elasticsearch healthcheck behavior for more reliable startup monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->