### PR TITLE
Update E2E test versions

### DIFF
--- a/.github/workflows/all-e2e-tests.yml
+++ b/.github/workflows/all-e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["9.5.0", "9.4.4", "8.19.19", "7.17.29"]
+        version: ["9.5.1", "9.4.5", "8.19.20", "7.17.29"]
         env: [docker, eck-2.16.1, eck-3.5.0]
     steps:
       - name: Checkout code
@@ -131,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ["9.5.0", "9.4.4", "8.19.19", "7.17.29"]
+        version: ["9.5.1", "9.4.5", "8.19.20", "7.17.29"]
         env: [docker, eck-2.16.1, eck-3.5.0]
     env:
       ROR_ES_VERSION: "latest"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test coverage to validate the latest Elasticsearch and Kibana versions.
  * Continued coverage for version 7.17.29.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->