### PR TITLE
[RORDEV-1229] Fix S3 upload of Cypress failure artifacts

### DIFF
--- a/.github/scripts/s3-uploader.sh
+++ b/.github/scripts/s3-uploader.sh
@@ -1,0 +1,150 @@
+#!/bin/bash -e
+
+usage()
+{
+    cat <<USAGE
+##########################################################################
+Originally adapted from https://www.aws.ps/how-to-upload-file-to-s3-using-curl
+(since modified for ROR: custom S3_ENDPOINT_URL, SigV4 date-scope fix, no ACL/MD5).
+
+Simple script uploading a file to S3 (or any S3-compatible endpoint). Supports AWS
+signature version 4, custom region, a custom endpoint, and mime-types.
+
+Usage:
+  `basename $0` aws_ak aws_sk bucket srcfile targfile [mime_type]
+
+Where <arg> is one of:
+  aws_ak     access key ('' for upload to public writable bucket)
+  aws_sk     secret key ('' for upload to public writable bucket)
+  bucket     bucket name (with optional @region suffix, default is us-east-1)
+  srcfile    path to source file
+  targfile   path to target (dir if it ends with '/', relative to bucket root)
+  mime_type  optional mime-type (tries to guess if omitted)
+
+Optional environment variables:
+  S3_ENDPOINT_URL  custom S3-compatible endpoint (uses path-style addressing).
+                   Defaults to https://<bucket>.s3.amazonaws.com/ when unset.
+
+Dependencies:
+  To run, this shell script depends on command-line curl and openssl, as well
+  as standard Unix tools
+
+Examples:
+  To upload file '~/blog/media/image.png' to bucket 'storage' in region
+  'eu-central-1' with key (path relative to bucket) 'media/image.png':
+
+\$  `basename $0` ACCESS SECRET storage@eu-central-1  ~/blog/image.png media/
+
+  To upload file '~/blog/media/image.png' to public-writable bucket 'storage'
+  in default region 'us-east-1' with key (path relative to bucket) 'x/y.png':
+
+    `basename $0` '' '' storage ~/blog/image.png x/y.png
+
+USAGE
+    exit 0
+}
+
+guessmime()
+{
+    mime=`file -b --mime-type $1`
+    if [ "$mime" = "text/plain" ] || [ "$mime" = "application/octet-stream" ]; then
+        case $1 in
+            *.zip)           mime=application/zip;;
+            *.sh)            mime=text/plain;;
+            *.sha1)          mime=text/plain;;
+            *.md)            mime=text/plain;;
+            *.json)          mime=application/json;;
+            *.css)           mime=text/css;;
+            *.ttf|*.otf)     mime=application/font-sfnt;;
+            *.woff)          mime=application/font-woff;;
+            *.woff2)         mime=font/woff2;;
+            *rss*.xml|*.rss) mime=application/rss+xml;;
+            *)               if head $1 | grep '<html.*>' >/dev/null; then mime=text/html; fi;;
+        esac
+    fi
+    printf "$mime"
+}
+
+if [ $# -lt 5 ]; then usage; fi
+
+# Inputs.
+aws_ak="$1"                                     # access key
+aws_sk="$2"                                     # secret key
+bucket=`printf $3 | awk 'BEGIN{FS="@"}{print $1}'`                       # bucket name
+region=`printf $3 | awk 'BEGIN{FS="@"}{print ($2==""?"us-east-1":$2)}'`  # region name
+srcfile="$4"                                                             # source file
+targfile=`echo -n "$5" | sed "s/\/$/\/$(basename $srcfile)/"`            # target file
+mime=${6:-"`guessmime "$srcfile"`"}                                      # mime type
+
+
+# Create signature if not public upload.
+key_and_sig_args=''
+if [ "$aws_ak" != "" ] && [ "$aws_sk" != "" ]; then
+
+    # SigV4 requires the credential scope date to match the request date.
+    # `today_s` is used for both signing and the X-Amz-Credential field.
+    # `expdate` is the policy expiration (tomorrow), unrelated to the credential date.
+    date=`date -u +%Y%m%dT%H%M%SZ`
+    today_s=`date -u +%Y%m%d`
+    expdate=`if ! date -v+1d +%Y-%m-%d 2>/dev/null; then date -d tomorrow +%Y-%m-%d; fi`
+    service='s3'
+
+    # Generate policy and sign with secret key following AWS Signature version 4, below
+    # -A suppresses base64 line wrapping (some S3-compatible proxies reject wrapped policies).
+    p=$(cat <<POLICY | openssl base64 -A
+{ "expiration": "${expdate}T12:00:00.000Z",
+  "conditions": [
+    {"bucket": "$bucket" },
+    ["starts-with", "\$key", ""],
+    ["starts-with", "\$content-type", ""],
+    ["content-length-range", 1, `ls -l -H "$srcfile" | awk '{print $5}' | head -1`],
+    {"x-amz-date": "$date" },
+    {"x-amz-credential": "$aws_ak/$today_s/$region/$service/aws4_request" },
+    {"x-amz-algorithm": "AWS4-HMAC-SHA256" }
+  ]
+}
+POLICY
+    )
+
+    # AWS4-HMAC-SHA256 signature.
+    # `awk '{print $NF}'` extracts just the hex digest from openssl output, which
+    # may be either "(stdin)= <hex>" (LibreSSL) or "SHA2-256(stdin)= <hex>" (OpenSSL 3+).
+    s=`printf "$today_s"     | openssl sha256 -hmac "AWS4$aws_sk"           -hex | awk '{print $NF}'`
+    s=`printf "$region"      | openssl sha256 -mac HMAC -macopt hexkey:"$s" -hex | awk '{print $NF}'`
+    s=`printf "$service"     | openssl sha256 -mac HMAC -macopt hexkey:"$s" -hex | awk '{print $NF}'`
+    s=`printf "aws4_request" | openssl sha256 -mac HMAC -macopt hexkey:"$s" -hex | awk '{print $NF}'`
+    s=`printf "$p"           | openssl sha256 -mac HMAC -macopt hexkey:"$s" -hex | awk '{print $NF}'`
+
+    # Policy goes here (not the curl line) so it's only sent when we actually signed — an
+    # anonymous upload (empty keys) leaves $p unset and must not send an empty Policy= field.
+    key_and_sig_args="-F X-Amz-Credential=$aws_ak/$today_s/$region/$service/aws4_request -F X-Amz-Algorithm=AWS4-HMAC-SHA256 -F X-Amz-Signature=$s -F X-Amz-Date=${date} -F Policy=$p"
+fi
+
+# Determine upload URL.
+# - If S3_ENDPOINT_URL is set (e.g. for the DGP proxy) use path-style addressing: ${endpoint}/${bucket}/
+# - Otherwise default to AWS virtual-hosted-style: https://${bucket}.s3.amazonaws.com/
+if [ -n "${S3_ENDPOINT_URL:-}" ]; then
+    upload_url="${S3_ENDPOINT_URL%/}/${bucket}/"
+else
+    upload_url="https://${bucket}.s3.amazonaws.com/"
+fi
+
+# Upload. Supports anonymous upload if bucket is public-writable, and keys are set to ''.
+echo "Uploading: $srcfile ($mime) to $upload_url$targfile"
+# Default: quiet upload that still fails loud. `-f` makes curl exit non-zero on HTTP >=400
+# (so callers detect failures) but it also SUPPRESSES the response body.
+# Set S3_UPLOADER_DEBUG=1 to debug: adds `-v` (verbose, incl. the full TLS handshake trace —
+# very noisy on curl 8.x/OpenSSL) and drops `-f` so curl prints the server's error XML.
+# `-v` is deliberately OFF by default, otherwise every upload floods the CI log with TLS traces.
+if [ -n "${S3_UPLOADER_DEBUG:-}" ]; then
+    CURL_FLAGS="-v -S"
+else
+    CURL_FLAGS="-f"
+fi
+curl                            \
+    -# $CURL_FLAGS              \
+    -F "key=$targfile"          \
+    $key_and_sig_args           \
+    -F "Content-Type=$mime"     \
+    -F "file=@$srcfile"         \
+    "$upload_url"

--- a/.github/scripts/upload-cypress-artifacts-to-s3.sh
+++ b/.github/scripts/upload-cypress-artifacts-to-s3.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+# Upload Cypress failure artifacts (videos, screenshots, logs) to S3, so a red e2e job leaves
+# something to look at after its runner is destroyed. Mirrors the ROR KBN repo's
+# scripts/uploadCypressArtifactsToS3.sh; kept as a script (not a run-pipeline.sh task) because the
+# workflow calls it from a separate `if: failure()` step, after run_e2e_tests has already returned.
+#
+# S3, not GitHub artifacts: those count against the metered Actions-storage quota.
+#
+# Usage: upload-cypress-artifacts-to-s3.sh <results dir> <s3 subfolder>
+#   e.g. upload-cypress-artifacts-to-s3.sh "$E2E_TESTS_DIR/results" es818x_8.19.19
+#
+# Uploads to the E2E_REPORTS store — the bucket's `e2e_reports/` tree, a sibling of the `builds/`
+# (ARTIFACTS) and `libs/` (LIBS) trees. Same env-var family as those, per ci-lib.sh's
+# ROR_<STORE>_STORE_* convention: ROR_E2E_REPORTS_STORE_{ACCESS_KEY_ID,ACCESS_KEY_SECRET,BUCKET,
+# REGION,ENDPOINT_URL,PATH_PREFIX}. It gets its own credentials because the gateway authorizes each
+# prefix separately — the publishing creds are 403ed here, and these must not be able to write to
+# the customer-facing builds/ tree.
+#
+# Final key: <PATH_PREFIX>/<s3 subfolder>/<path within results dir>.
+
+# Deliberately no `-e`: one failed upload must not skip the remaining files.
+set -uo pipefail
+
+CI_DIR="$(cd "$(dirname "$0")" && pwd)"
+STORE=E2E_REPORTS
+
+# Resolve this store's env vars indirectly, exactly as ci-lib.sh's upload_using_aws_s3_uploader does
+# (that helper takes one file with a guessed mime type; this one walks a tree and passes an explicit
+# mime, so it drives ci/s3-uploader.sh itself rather than going through it).
+AK_VAR="ROR_${STORE}_STORE_ACCESS_KEY_ID"
+SK_VAR="ROR_${STORE}_STORE_ACCESS_KEY_SECRET"
+BUCKET_VAR="ROR_${STORE}_STORE_BUCKET"
+REGION_VAR="ROR_${STORE}_STORE_REGION"
+ENDPOINT_VAR="ROR_${STORE}_STORE_ENDPOINT_URL"
+PREFIX_VAR="ROR_${STORE}_STORE_PATH_PREFIX"
+
+require_env() {
+  if [ -z "${!1:-}" ]; then
+    echo "ERROR: $1 is not set (required to upload the Cypress artifacts)"
+    return 1
+  fi
+}
+
+# REGION and ENDPOINT_URL are as mandatory as the credentials: without REGION the uploader silently
+# signs for us-east-1, which the MinIO/DGP endpoint rejects, and without ENDPOINT_URL it addresses
+# real AWS S3, where these credentials mean nothing. Both fail with opaque 403s, so fail early.
+for VAR in "$AK_VAR" "$SK_VAR" "$BUCKET_VAR" "$REGION_VAR" "$ENDPOINT_VAR"; do
+  require_env "$VAR" || exit 1
+done
+
+AK="${!AK_VAR}"
+SK="${!SK_VAR}"
+BUCKET="${!BUCKET_VAR}"
+REGION="${!REGION_VAR}"
+PATH_PREFIX="${!PREFIX_VAR:-}"
+
+SOURCE_DIR="${1:?Usage: upload-cypress-artifacts-to-s3.sh <results dir> <s3 subfolder>}"
+S3_SUBFOLDER="${2:?Usage: upload-cypress-artifacts-to-s3.sh <results dir> <s3 subfolder>}"
+
+if [ ! -d "$SOURCE_DIR" ]; then
+  echo "No Cypress results directory at $SOURCE_DIR — nothing to upload."
+  echo "(the suite may have failed before producing any, e.g. while the stack was starting)"
+  exit 0
+fi
+
+S3_PATH="${PATH_PREFIX:+${PATH_PREFIX%/}/}${S3_SUBFOLDER%/}/"
+
+# Consumed by s3-uploader.sh, which switches to path-style addressing when it is set.
+export S3_ENDPOINT_URL="${!ENDPOINT_VAR}"
+
+# An explicit mime type keeps the uploader from calling `file` (its guess path), which is not
+# guaranteed to exist on a bare runner. Without it the Content-Type comes out empty, the signed-POST
+# policy rejects the malformed form, and the upload 403s.
+mime_of() {
+  case "$1" in
+    *.mp4) echo "video/mp4" ;;
+    *.png) echo "image/png" ;;
+    *.log | *.txt) echo "text/plain" ;;
+    *.json) echo "application/json" ;;
+    *.xml) echo "application/xml" ;;
+    *) echo "application/octet-stream" ;;
+  esac
+}
+
+upload_one() {
+  local FILE=$1 KEY=$2 MIME=$3
+  "$CI_DIR/s3-uploader.sh" "$AK" "$SK" "${BUCKET}@${REGION}" "$FILE" "$KEY" "$MIME"
+}
+
+UPLOADED=0
+SKIPPED_EMPTY=0
+FAILED=0
+DIAGNOSED=false
+
+# -print0/read -d '' so paths with spaces survive; the relative path becomes the key, keeping the
+# videos/ vs screenshots/ split visible in the bucket.
+while IFS= read -r -d '' FILE; do
+  # Cypress leaves 0-byte *-compressed.mp4 placeholders for specs that passed. The signed-POST policy
+  # enforces content-length-range >= 1, so uploading one is a guaranteed 403.
+  if [ ! -s "$FILE" ]; then
+    SKIPPED_EMPTY=$((SKIPPED_EMPTY + 1))
+    continue
+  fi
+
+  REL=${FILE#"$SOURCE_DIR"/}
+  MIME=$(mime_of "$FILE")
+  if upload_one "$FILE" "${S3_PATH}${REL}" "$MIME"; then
+    UPLOADED=$((UPLOADED + 1))
+    continue
+  fi
+
+  echo "WARNING: upload failed for $FILE (continuing)"
+  FAILED=$((FAILED + 1))
+  # s3-uploader.sh uses `curl -f`, which hides the server's error body. On the FIRST failure only,
+  # re-run it with S3_UPLOADER_DEBUG=1 to capture the actual S3 error XML (AccessDenied /
+  # SignatureDoesNotMatch / a policy condition) — without it a 403 is unattributable.
+  if [ "$DIAGNOSED" = false ]; then
+    DIAGNOSED=true
+    echo "----- S3 failure diagnostic: re-uploading $REL to capture the error body -----"
+    (S3_UPLOADER_DEBUG=1 upload_one "$FILE" "${S3_PATH}${REL}" "$MIME" 2>&1 | sed 's/^/[s3-debug] /') || true
+    echo "----- end diagnostic -----"
+  fi
+done < <(find "$SOURCE_DIR" -type f -print0)
+
+echo "S3 upload summary: uploaded=$UPLOADED skipped_empty=$SKIPPED_EMPTY failed=$FAILED"
+if [ "$UPLOADED" -gt 0 ]; then
+  echo "Uploaded $UPLOADED Cypress artifact(s) to s3://${BUCKET}/${S3_PATH}"
+elif [ "$FAILED" -eq 0 ]; then
+  echo "No Cypress artifacts found in $SOURCE_DIR — nothing to upload."
+fi

--- a/.github/upload-videos/action.yml
+++ b/.github/upload-videos/action.yml
@@ -28,16 +28,18 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    # The upload itself is .github/scripts/upload-cypress-artifacts-to-s3.sh, a verbatim copy of
-    # ci/upload-cypress-artifacts-to-s3.sh in the ROR ES repo (with its ci/s3-uploader.sh helper) so
-    # the two stay diffable. It signs its own PUTs with curl instead of using the AWS CLI, which is
-    # what killed the previous implementation: CLI v2.23+ streams PutObject as `aws-chunked` with a
-    # trailing CRC32, and the endpoint answers `InvalidArgument: Failed to decode AWS chunked
-    # transfer encoding`. Everything repo-specific stays here, in the env mapping below.
+    # .github/scripts/upload-cypress-artifacts-to-s3.sh sends the files. It is a copy of
+    # ci/upload-cypress-artifacts-to-s3.sh in the ROR ES repo. Its helper, s3-uploader.sh, is also a
+    # copy. Do not change the two copies, so that you can compare them with the originals.
+    # The script signs each PUT with curl. It does not use the AWS CLI, which broke the earlier
+    # version of this step: CLI v2.23 and subsequent versions send the body in `aws-chunked` format
+    # with a CRC32 at the end. Our S3 endpoint cannot read that format. It replies:
+    #   InvalidArgument: Failed to decode AWS chunked transfer encoding
+    # The values that are different in this repository stay below, in the env block.
     - name: Upload Cypress artifacts to S3
       shell: bash
       env:
-        # The scripts read one env family, ROR_<STORE>_STORE_*, per the ES repo's convention.
+        # The scripts read the ROR_<STORE>_STORE_* variables. This is the ROR ES repo convention.
         ROR_E2E_REPORTS_STORE_ACCESS_KEY_ID: ${{ inputs.access_key_id }}
         ROR_E2E_REPORTS_STORE_ACCESS_KEY_SECRET: ${{ inputs.secret_access_key }}
         ROR_E2E_REPORTS_STORE_BUCKET: ${{ inputs.bucket }}
@@ -45,7 +47,7 @@ runs:
         ROR_E2E_REPORTS_STORE_ENDPOINT_URL: ${{ inputs.endpoint_url }}
         ROR_E2E_REPORTS_STORE_PATH_PREFIX: ror/e2e_reports/build_${{ github.run_id }}
         RESULTS_DIR: ${{ inputs.results_dir }}
-        # Keeps the pre-existing key layout: <prefix>/<env>/<version>/<videos|screenshots>/<file>.
+        # This keeps the old key layout: <prefix>/<env>/<version>/<videos|screenshots>/<file>.
         S3_SUBFOLDER: ${{ matrix.env }}/${{ matrix.version }}
       run: |
         echo "::add-mask::${ROR_E2E_REPORTS_STORE_ACCESS_KEY_ID}"

--- a/.github/upload-videos/action.yml
+++ b/.github/upload-videos/action.yml
@@ -28,18 +28,9 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    # .github/scripts/upload-cypress-artifacts-to-s3.sh sends the files. It is a copy of
-    # ci/upload-cypress-artifacts-to-s3.sh in the ROR ES repo. Its helper, s3-uploader.sh, is also a
-    # copy. Do not change the two copies, so that you can compare them with the originals.
-    # The script signs each PUT with curl. It does not use the AWS CLI, which broke the earlier
-    # version of this step: CLI v2.23 and subsequent versions send the body in `aws-chunked` format
-    # with a CRC32 at the end. Our S3 endpoint cannot read that format. It replies:
-    #   InvalidArgument: Failed to decode AWS chunked transfer encoding
-    # The values that are different in this repository stay below, in the env block.
     - name: Upload Cypress artifacts to S3
       shell: bash
       env:
-        # The scripts read the ROR_<STORE>_STORE_* variables. This is the ROR ES repo convention.
         ROR_E2E_REPORTS_STORE_ACCESS_KEY_ID: ${{ inputs.access_key_id }}
         ROR_E2E_REPORTS_STORE_ACCESS_KEY_SECRET: ${{ inputs.secret_access_key }}
         ROR_E2E_REPORTS_STORE_BUCKET: ${{ inputs.bucket }}
@@ -47,7 +38,6 @@ runs:
         ROR_E2E_REPORTS_STORE_ENDPOINT_URL: ${{ inputs.endpoint_url }}
         ROR_E2E_REPORTS_STORE_PATH_PREFIX: ror/e2e_reports/build_${{ github.run_id }}
         RESULTS_DIR: ${{ inputs.results_dir }}
-        # This keeps the old key layout: <prefix>/<env>/<version>/<videos|screenshots>/<file>.
         S3_SUBFOLDER: ${{ matrix.env }}/${{ matrix.version }}
       run: |
         echo "::add-mask::${ROR_E2E_REPORTS_STORE_ACCESS_KEY_ID}"

--- a/.github/upload-videos/action.yml
+++ b/.github/upload-videos/action.yml
@@ -1,5 +1,5 @@
 name: 'Upload Videos'
-description: 'Upload videos to S3 bucket'
+description: 'Upload Cypress failure artifacts (videos, screenshots) to an S3 bucket'
 
 inputs:
   region:
@@ -20,18 +20,34 @@ inputs:
   secret_access_key:
     description: 'AWS secret access key'
     required: true
+  results_dir:
+    description: 'Cypress results directory to upload (videos/ and screenshots/ live here)'
+    required: false
+    default: 'results'
 
 runs:
   using: 'composite'
   steps:
-    - name: Upload videos to S3
+    # The upload itself is .github/scripts/upload-cypress-artifacts-to-s3.sh, a verbatim copy of
+    # ci/upload-cypress-artifacts-to-s3.sh in the ROR ES repo (with its ci/s3-uploader.sh helper) so
+    # the two stay diffable. It signs its own PUTs with curl instead of using the AWS CLI, which is
+    # what killed the previous implementation: CLI v2.23+ streams PutObject as `aws-chunked` with a
+    # trailing CRC32, and the endpoint answers `InvalidArgument: Failed to decode AWS chunked
+    # transfer encoding`. Everything repo-specific stays here, in the env mapping below.
+    - name: Upload Cypress artifacts to S3
       shell: bash
       env:
-        AWS_ACCESS_KEY_ID: ${{ inputs.access_key_id }}
-        AWS_SECRET_ACCESS_KEY: ${{ inputs.secret_access_key }}
-        AWS_ENDPOINT_URL: ${{ inputs.endpoint_url }}
+        # The scripts read one env family, ROR_<STORE>_STORE_*, per the ES repo's convention.
+        ROR_E2E_REPORTS_STORE_ACCESS_KEY_ID: ${{ inputs.access_key_id }}
+        ROR_E2E_REPORTS_STORE_ACCESS_KEY_SECRET: ${{ inputs.secret_access_key }}
+        ROR_E2E_REPORTS_STORE_BUCKET: ${{ inputs.bucket }}
+        ROR_E2E_REPORTS_STORE_REGION: ${{ inputs.region }}
+        ROR_E2E_REPORTS_STORE_ENDPOINT_URL: ${{ inputs.endpoint_url }}
+        ROR_E2E_REPORTS_STORE_PATH_PREFIX: ror/e2e_reports/build_${{ github.run_id }}
+        RESULTS_DIR: ${{ inputs.results_dir }}
+        # Keeps the pre-existing key layout: <prefix>/<env>/<version>/<videos|screenshots>/<file>.
+        S3_SUBFOLDER: ${{ matrix.env }}/${{ matrix.version }}
       run: |
-        echo "::add-mask::${AWS_ACCESS_KEY_ID}"
-        echo "::add-mask::${AWS_SECRET_ACCESS_KEY}"
-        aws configure set region ${{ inputs.region }}
-        aws s3 cp results/videos/ s3://${{ inputs.bucket }}/ror/e2e_reports/build_${{ github.run_id }}/${{ matrix.env }}/${{ matrix.version }}/ --recursive
+        echo "::add-mask::${ROR_E2E_REPORTS_STORE_ACCESS_KEY_ID}"
+        echo "::add-mask::${ROR_E2E_REPORTS_STORE_ACCESS_KEY_SECRET}"
+        "$GITHUB_ACTION_PATH/../scripts/upload-cypress-artifacts-to-s3.sh" "$RESULTS_DIR" "$S3_SUBFOLDER"

--- a/.github/workflows/all-e2e-tests.yml
+++ b/.github/workflows/all-e2e-tests.yml
@@ -65,7 +65,7 @@ jobs:
           action: stop
       - name: S3 Upload Videos & show logs
         if: failure()
-        # A failed post-mortem upload must not add a second red X to an already-red job.
+        # The job already failed. If this upload also fails, do not fail the job again.
         continue-on-error: true
         uses: ./.github/upload-videos
         with:
@@ -177,7 +177,7 @@ jobs:
           action: stop
       - name: S3 Upload Videos & show logs
         if: failure()
-        # A failed post-mortem upload must not add a second red X to an already-red job.
+        # The job already failed. If this upload also fails, do not fail the job again.
         continue-on-error: true
         uses: ./.github/upload-videos
         with:

--- a/.github/workflows/all-e2e-tests.yml
+++ b/.github/workflows/all-e2e-tests.yml
@@ -65,7 +65,6 @@ jobs:
           action: stop
       - name: S3 Upload Videos & show logs
         if: failure()
-        # The job already failed. If this upload also fails, do not fail the job again.
         continue-on-error: true
         uses: ./.github/upload-videos
         with:
@@ -177,7 +176,6 @@ jobs:
           action: stop
       - name: S3 Upload Videos & show logs
         if: failure()
-        # The job already failed. If this upload also fails, do not fail the job again.
         continue-on-error: true
         uses: ./.github/upload-videos
         with:

--- a/.github/workflows/all-e2e-tests.yml
+++ b/.github/workflows/all-e2e-tests.yml
@@ -65,6 +65,8 @@ jobs:
           action: stop
       - name: S3 Upload Videos & show logs
         if: failure()
+        # A failed post-mortem upload must not add a second red X to an already-red job.
+        continue-on-error: true
         uses: ./.github/upload-videos
         with:
           access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -175,7 +177,10 @@ jobs:
           action: stop
       - name: S3 Upload Videos & show logs
         if: failure()
+        # A failed post-mortem upload must not add a second red X to an already-red job.
+        continue-on-error: true
         uses: ./.github/upload-videos
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        with:
+          access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          endpoint_url: ${{ secrets.AWS_ENDPOINT_URL }}

--- a/.github/workflows/targeted-e2e-tests.yml
+++ b/.github/workflows/targeted-e2e-tests.yml
@@ -80,6 +80,8 @@ jobs:
 
       - name: S3 Upload Videos & show logs
         if: failure()
+        # A failed post-mortem upload must not add a second red X to an already-red job.
+        continue-on-error: true
         uses: ./.github/upload-videos
         with:
           access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/targeted-e2e-tests.yml
+++ b/.github/workflows/targeted-e2e-tests.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: S3 Upload Videos & show logs
         if: failure()
-        # A failed post-mortem upload must not add a second red X to an already-red job.
+        # The job already failed. If this upload also fails, do not fail the job again.
         continue-on-error: true
         uses: ./.github/upload-videos
         with:


### PR DESCRIPTION
Every video upload from a red e2e job was dying with:

  InvalidArgument: Failed to decode AWS chunked transfer encoding

AWS CLI v2.23+ enables flexible checksums by default, streaming PutObject bodies as `Content-Encoding: aws-chunked` with a trailing CRC32, which the S3-compatible endpoint behind AWS_ENDPOINT_URL cannot decode. So a failed run left nothing behind to diagnose it with.

Drop the `aws s3 cp` one-liner for .github/scripts/upload-cypress-artifacts- to-s3.sh and its .github/scripts/s3-uploader.sh helper — byte-identical copies of ci/*.sh in elasticsearch-readonlyrest-plugin, so the two repos stay diffable. They sign their own PUTs with curl, taking the AWS CLI (and its chunked-body default) out of the picture. Everything repo-specific — the credentials, bucket, endpoint and key layout — stays in the composite action's env mapping, so no new secrets are needed.

What the scripts additionally get right:
- a missing results dir is not an error. The suite can die before Cypress writes anything (e.g. while the stack is starting), and `aws s3 cp` on the absent path exited 255, reporting the post-mortem step's own failure instead of the real one
- the 0-byte *-compressed.mp4 placeholders Cypress leaves for green specs are skipped
- screenshots are uploaded too, not just videos
- one rejected file does not skip the rest, and the first failure is re-run with debug on to capture the S3 error body

Keys keep the previous layout, gaining only the videos/ vs screenshots/ split:
  ror/e2e_reports/build_<run id>/<env>/<version>/videos/<spec>.mp4

The three call sites become continue-on-error, as the ES repo's step is: a failed post-mortem upload must not add a second red X to an already-red job.
