### PR TITLE
[RORDEV-2136][RORDEV-1229] Clear reports between tests, and keep artifact file names intact

### DIFF
--- a/.github/scripts/s3-uploader.sh
+++ b/.github/scripts/s3-uploader.sh
@@ -46,7 +46,7 @@ USAGE
 
 guessmime()
 {
-    mime=`file -b --mime-type $1`
+    mime=`file -b --mime-type "$1"`
     if [ "$mime" = "text/plain" ] || [ "$mime" = "application/octet-stream" ]; then
         case $1 in
             *.zip)           mime=application/zip;;
@@ -59,7 +59,7 @@ guessmime()
             *.woff)          mime=application/font-woff;;
             *.woff2)         mime=font/woff2;;
             *rss*.xml|*.rss) mime=application/rss+xml;;
-            *)               if head $1 | grep '<html.*>' >/dev/null; then mime=text/html; fi;;
+            *)               if head "$1" | grep '<html.*>' >/dev/null; then mime=text/html; fi;;
         esac
     fi
     printf "$mime"
@@ -73,7 +73,7 @@ aws_sk="$2"                                     # secret key
 bucket=`printf $3 | awk 'BEGIN{FS="@"}{print $1}'`                       # bucket name
 region=`printf $3 | awk 'BEGIN{FS="@"}{print ($2==""?"us-east-1":$2)}'`  # region name
 srcfile="$4"                                                             # source file
-targfile=`echo -n "$5" | sed "s/\/$/\/$(basename $srcfile)/"`            # target file
+targfile=`echo -n "$5" | sed "s/\/$/\/$(basename "$srcfile")/"`          # target file
 mime=${6:-"`guessmime "$srcfile"`"}                                      # mime type
 
 
@@ -141,10 +141,13 @@ if [ -n "${S3_UPLOADER_DEBUG:-}" ]; then
 else
     CURL_FLAGS="-f"
 fi
+# The file name goes in curl's own quotes: in -F, an unquoted @path ends at a ',' or ';', so a spec
+# name that holds either would send a truncated file. $key_and_sig_args stays unquoted on purpose —
+# it is several arguments, and must split.
 curl                            \
     -# $CURL_FLAGS              \
     -F "key=$targfile"          \
     $key_and_sig_args           \
     -F "Content-Type=$mime"     \
-    -F "file=@$srcfile"         \
+    -F "file=@\"$srcfile\""   \
     "$upload_url"

--- a/e2e-tests/cypress/support/helpers/EsApiAdvancedClient.ts
+++ b/e2e-tests/cypress/support/helpers/EsApiAdvancedClient.ts
@@ -1,7 +1,5 @@
-import * as semver from 'semver';
 import { recurse } from 'cypress-recurse';
 import { EsApiClient } from './EsApiClient';
-import { getKibanaVersion } from './index';
 
 export class EsApiAdvancedClient extends EsApiClient {
   public pruneAllReportingIndices(): void {
@@ -19,17 +17,17 @@ export class EsApiAdvancedClient extends EsApiClient {
         });
     });
 
-    // Pre-8.19 also has the legacy .reporting* indices; purge their docs too.
-    if (!semver.satisfies(getKibanaVersion(), '>=8.19.0 <9.0.0 || >=9.1.0')) {
-      this.indices().then(result => {
-        result
-          .filter(index => index.index.startsWith('.reporting'))
-          .forEach(reportingIndex => {
-            this.deleteIndexDocsByQuery(reportingIndex.index);
-            this.refreshIndex(reportingIndex.index);
-          });
-      });
-    }
+    // The legacy .reporting* indices hold reports too, in every version: the reporting page lists
+    // what it finds in both places, and a test writes an old-format doc to prove it. Purge their
+    // docs as well, or a report the page still shows outlives the test that made it.
+    this.indices().then(result => {
+      result
+        .filter(index => index.index.startsWith('.reporting'))
+        .forEach(reportingIndex => {
+          this.deleteIndexDocsByQuery(reportingIndex.index);
+          this.refreshIndex(reportingIndex.index);
+        });
+    });
 
     cy.log('Pruning all reporting indices - DONE!');
   }


### PR DESCRIPTION
## Reports from one test stayed visible in the next

The reporting page lists what it finds in two places: the `.kibana-reporting-*` data stream, and the
older `.reporting*` indices. `Reporting.cy.ts` depends on this — it writes an old-format document and
expects a row for it.

`pruneAllReportingIndices()` emptied the legacy indices only below Kibana 8.19/9.1. On a 9.x stack a
report written there stayed after the test that made it, and the next test saw a row it did not
create. The helper now empties both places, in every version.

## Failure screenshots did not reach S3

`curl -F` reads an unquoted `@path` up to a `,` or a `;`, so a file whose name holds either was sent
truncated. Cypress names a failure screenshot after the test, so this reached only the artifacts of a
red run — the pictures somebody needs to see. The name is now quoted, here and in the two other
places in the script that read it.

## Effect

Fewer rows that no test made, and a red run keeps its pictures.
