### PR TITLE
Use one S3 credential set and consistent CI secret names

### DIFF
--- a/.github/scripts/upload-cypress-artifacts-to-s3.sh
+++ b/.github/scripts/upload-cypress-artifacts-to-s3.sh
@@ -11,13 +11,11 @@
 #   e.g. upload-cypress-artifacts-to-s3.sh "$E2E_TESTS_DIR/results" es818x_8.19.19
 #
 # Uploads to the E2E_REPORTS store — the bucket's `e2e_reports/` tree, a sibling of the `builds/`
-# (ARTIFACTS) and `libs/` (LIBS) trees. Same env-var family as those, per ci-lib.sh's
-# ROR_<STORE>_STORE_* convention: ROR_E2E_REPORTS_STORE_{ACCESS_KEY_ID,ACCESS_KEY_SECRET,BUCKET,
-# REGION,ENDPOINT_URL,PATH_PREFIX}. It gets its own credentials because the gateway authorizes each
-# prefix separately — the publishing creds are 403ed here, and these must not be able to write to
-# the customer-facing builds/ tree.
+# (ARTIFACTS) and `libs/` (LIBS) trees. One credential set serves all three, per ci-lib.sh:
+# ROR_S3_{ACCESS_KEY_ID,SECRET_ACCESS_KEY,BUCKET,REGION,ENDPOINT_URL}. The store name selects
+# only the key prefix, ROR_S3_PATH_E2E_REPORTS.
 #
-# Final key: <PATH_PREFIX>/<s3 subfolder>/<path within results dir>.
+# Final key: <ROR_S3_PATH_E2E_REPORTS>/<s3 subfolder>/<path within results dir>.
 
 # Deliberately no `-e`: one failed upload must not skip the remaining files.
 set -uo pipefail
@@ -25,15 +23,15 @@ set -uo pipefail
 CI_DIR="$(cd "$(dirname "$0")" && pwd)"
 STORE=E2E_REPORTS
 
-# Resolve this store's env vars indirectly, exactly as ci-lib.sh's upload_using_aws_s3_uploader does
-# (that helper takes one file with a guessed mime type; this one walks a tree and passes an explicit
-# mime, so it drives ci/s3-uploader.sh itself rather than going through it).
-AK_VAR="ROR_${STORE}_STORE_ACCESS_KEY_ID"
-SK_VAR="ROR_${STORE}_STORE_ACCESS_KEY_SECRET"
-BUCKET_VAR="ROR_${STORE}_STORE_BUCKET"
-REGION_VAR="ROR_${STORE}_STORE_REGION"
-ENDPOINT_VAR="ROR_${STORE}_STORE_ENDPOINT_URL"
-PREFIX_VAR="ROR_${STORE}_STORE_PATH_PREFIX"
+# Credentials are flat; only the path prefix is resolved through the store name, exactly as
+# ci-lib.sh's upload_using_aws_s3_uploader does (that helper takes one file with a guessed mime
+# type; this one walks a tree and passes an explicit mime, so it drives ci/s3-uploader.sh itself).
+AK_VAR="ROR_S3_ACCESS_KEY_ID"
+SK_VAR="ROR_S3_SECRET_ACCESS_KEY"
+BUCKET_VAR="ROR_S3_BUCKET"
+REGION_VAR="ROR_S3_REGION"
+ENDPOINT_VAR="ROR_S3_ENDPOINT_URL"
+PREFIX_VAR="ROR_S3_PATH_${STORE}"
 
 require_env() {
   if [ -z "${!1:-}" ]; then

--- a/.github/upload-videos/action.yml
+++ b/.github/upload-videos/action.yml
@@ -3,22 +3,22 @@ description: 'Upload Cypress failure artifacts (videos, screenshots) to an S3 bu
 
 inputs:
   region:
-    description: 'AWS region'
+    description: 'S3 region (the DGP gateway ignores it, but SigV4 must sign with something)'
     required: true
-    default: 'eu-west-1'
   bucket:
     description: 'S3 bucket name'
     required: true
-    default: 'beshu'
   endpoint_url:
     description: 'S3 endpoint URL'
-    required: false
-    default: ''
+    required: true
+  path_prefix:
+    description: 'Key prefix for the e2e reports store'
+    required: true
   access_key_id:
-    description: 'AWS access key ID'
+    description: 'S3 access key ID'
     required: true
   secret_access_key:
-    description: 'AWS secret access key'
+    description: 'S3 secret access key'
     required: true
   results_dir:
     description: 'Cypress results directory to upload (videos/ and screenshots/ live here)'
@@ -31,15 +31,15 @@ runs:
     - name: Upload Cypress artifacts to S3
       shell: bash
       env:
-        ROR_E2E_REPORTS_STORE_ACCESS_KEY_ID: ${{ inputs.access_key_id }}
-        ROR_E2E_REPORTS_STORE_ACCESS_KEY_SECRET: ${{ inputs.secret_access_key }}
-        ROR_E2E_REPORTS_STORE_BUCKET: ${{ inputs.bucket }}
-        ROR_E2E_REPORTS_STORE_REGION: ${{ inputs.region }}
-        ROR_E2E_REPORTS_STORE_ENDPOINT_URL: ${{ inputs.endpoint_url }}
-        ROR_E2E_REPORTS_STORE_PATH_PREFIX: ror/e2e_reports/build_${{ github.run_id }}
+        ROR_S3_ACCESS_KEY_ID: ${{ inputs.access_key_id }}
+        ROR_S3_SECRET_ACCESS_KEY: ${{ inputs.secret_access_key }}
+        ROR_S3_BUCKET: ${{ inputs.bucket }}
+        ROR_S3_REGION: ${{ inputs.region }}
+        ROR_S3_ENDPOINT_URL: ${{ inputs.endpoint_url }}
+        ROR_S3_PATH_E2E_REPORTS: ${{ inputs.path_prefix }}/build_${{ github.run_id }}
         RESULTS_DIR: ${{ inputs.results_dir }}
         S3_SUBFOLDER: ${{ matrix.env }}/${{ matrix.version }}
       run: |
-        echo "::add-mask::${ROR_E2E_REPORTS_STORE_ACCESS_KEY_ID}"
-        echo "::add-mask::${ROR_E2E_REPORTS_STORE_ACCESS_KEY_SECRET}"
+        echo "::add-mask::${ROR_S3_ACCESS_KEY_ID}"
+        echo "::add-mask::${ROR_S3_SECRET_ACCESS_KEY}"
         "$GITHUB_ACTION_PATH/../scripts/upload-cypress-artifacts-to-s3.sh" "$RESULTS_DIR" "$S3_SUBFOLDER"

--- a/.github/workflows/all-e2e-tests.yml
+++ b/.github/workflows/all-e2e-tests.yml
@@ -64,7 +64,7 @@ jobs:
           command: |
             ./runner.sh --run e2e --env ${{ matrix.env }} --elk ${{ matrix.version }} --mode prod
         env:
-          ROR_ACTIVATION_KEY: ${{ secrets.ROR_KBN_LICENSE }}
+          ROR_ACTIVATION_KEY: ${{ secrets.ROR_ENT_ACTIVATION_TOKEN }}
           ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
       - name: Stop Docker memory monitor
         if: always()
@@ -76,9 +76,12 @@ jobs:
         continue-on-error: true
         uses: ./.github/upload-videos
         with:
-          access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          endpoint_url: ${{ secrets.AWS_ENDPOINT_URL }}
+          access_key_id: ${{ secrets.ROR_S3_ACCESS_KEY_ID }}
+          secret_access_key: ${{ secrets.ROR_S3_SECRET_ACCESS_KEY }}
+          endpoint_url: ${{ vars.ROR_S3_ENDPOINT_URL }}
+          bucket: ${{ vars.ROR_S3_BUCKET }}
+          region: ${{ vars.ROR_S3_REGION }}
+          path_prefix: ${{ vars.ROR_S3_PATH_E2E_REPORTS }}
 
   # ==========================================
   # BOOTSTRAP TESTS
@@ -123,7 +126,7 @@ jobs:
           command: |
             ./runner.sh --run bootstrap --env ${{ matrix.env }} --elk ${{ matrix.version }}
         env:
-          ROR_ACTIVATION_KEY: ${{ secrets.ROR_KBN_LICENSE }}
+          ROR_ACTIVATION_KEY: ${{ secrets.ROR_ENT_ACTIVATION_TOKEN }}
       - name: Stop Docker memory monitor
         if: always()
         uses: ./.github/docker-memory-monitor
@@ -161,8 +164,8 @@ jobs:
           # from the merge ref github.ref points at. On a push, head_ref is empty and ref_name is
           # the branch that was pushed (develop).
           TARGET_BRANCH: ${{ github.head_ref || github.ref_name }}
-          ES_REPO_GH_TOKEN: ${{ secrets.ES_REPO_GH_TOKEN }}
-          KBN_REPO_GH_TOKEN: ${{ secrets.KBN_REPO_GH_TOKEN }}
+          ROR_GH_TOKEN: ${{ secrets.ROR_GH_TOKEN }}
+
         run: |
           set -euo pipefail
           . ci/prebuild-images-lib.sh
@@ -223,7 +226,7 @@ jobs:
           command: |
             ./runner.sh --run e2e --env ${{ matrix.env }} --elk ${{ matrix.version }} --ror-es ${{ env.ROR_IMAGE_TAG }} --ror-kbn ${{ env.ROR_IMAGE_TAG }} --mode dev
         env:
-          ROR_ACTIVATION_KEY: ${{ secrets.ROR_KBN_LICENSE }}
+          ROR_ACTIVATION_KEY: ${{ secrets.ROR_ENT_ACTIVATION_TOKEN }}
 
       - name: Stop Docker memory monitor
         if: always()
@@ -235,6 +238,9 @@ jobs:
         continue-on-error: true
         uses: ./.github/upload-videos
         with:
-          access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          endpoint_url: ${{ secrets.AWS_ENDPOINT_URL }}
+          access_key_id: ${{ secrets.ROR_S3_ACCESS_KEY_ID }}
+          secret_access_key: ${{ secrets.ROR_S3_SECRET_ACCESS_KEY }}
+          endpoint_url: ${{ vars.ROR_S3_ENDPOINT_URL }}
+          bucket: ${{ vars.ROR_S3_BUCKET }}
+          region: ${{ vars.ROR_S3_REGION }}
+          path_prefix: ${{ vars.ROR_S3_PATH_E2E_REPORTS }}

--- a/.github/workflows/targeted-e2e-tests.yml
+++ b/.github/workflows/targeted-e2e-tests.yml
@@ -64,7 +64,7 @@ jobs:
             [ -n "$MODE" ] && PARAMS+=(--mode "$MODE")
             ./runner.sh "${PARAMS[@]}"
         env:
-          ROR_ACTIVATION_KEY: ${{ secrets.ROR_KBN_LICENSE }}
+          ROR_ACTIVATION_KEY: ${{ secrets.ROR_ENT_ACTIVATION_TOKEN }}
           ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
           ENV: ${{ github.event.inputs.env }}
           ELK_VERSION: ${{ github.event.inputs.elk_version }}
@@ -84,6 +84,9 @@ jobs:
         continue-on-error: true
         uses: ./.github/upload-videos
         with:
-          access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          endpoint_url: ${{ secrets.AWS_ENDPOINT_URL }}
+          access_key_id: ${{ secrets.ROR_S3_ACCESS_KEY_ID }}
+          secret_access_key: ${{ secrets.ROR_S3_SECRET_ACCESS_KEY }}
+          endpoint_url: ${{ vars.ROR_S3_ENDPOINT_URL }}
+          bucket: ${{ vars.ROR_S3_BUCKET }}
+          region: ${{ vars.ROR_S3_REGION }}
+          path_prefix: ${{ vars.ROR_S3_PATH_E2E_REPORTS }}

--- a/ci/prebuild-images-lib.sh
+++ b/ci/prebuild-images-lib.sh
@@ -291,18 +291,18 @@ dispatch_kbn_prebuild_image() {
   RUN_TAG=$3
   FORCE_REBUILD=${4:-false}
 
-  _require_dispatch_token KBN_REPO_GH_TOKEN "ROR KBN" || return $?
+  _require_dispatch_token ROR_GH_TOKEN "ROR KBN" || return $?
 
   local WORKFLOW_REF
   WORKFLOW_REF=$(_resolve_workflow_ref "$ROR_KBN_PUBLISH_WORKFLOW_REF" "$ROR_KBN_GH_REPO" \
-    "$KBN_REPO_GH_TOKEN" "$TARGET_BRANCH" "$ROR_KBN_PUBLISH_WORKFLOW_FALLBACK_REF")
+    "$ROR_GH_TOKEN" "$TARGET_BRANCH" "$ROR_KBN_PUBLISH_WORKFLOW_FALLBACK_REF")
 
   echo ""
   echo ">>> Dispatching ROR KBN pre-build: versions=$KBN_VERSIONS tag=$RUN_TAG branch=$TARGET_BRANCH${WORKFLOW_REF:+ (workflow ref: $WORKFLOW_REF)}"
 
   # Same naming rule as ES below: these must match the workflow's inputs on its default branch.
   _dispatch_prebuild_workflow "ROR KBN" \
-    "$ROR_KBN_GH_REPO" "$ROR_KBN_PUBLISH_WORKFLOW" "$WORKFLOW_REF" "$KBN_REPO_GH_TOKEN" \
+    "$ROR_KBN_GH_REPO" "$ROR_KBN_PUBLISH_WORKFLOW" "$WORKFLOW_REF" "$ROR_GH_TOKEN" \
     -f "kbn_versions=$KBN_VERSIONS" \
     -f "target_branch=$TARGET_BRANCH" \
     -f "tag=$RUN_TAG" \
@@ -327,11 +327,11 @@ dispatch_es_prebuild_image() {
   RUN_TAG=$3
   FORCE_REBUILD=${4:-false}
 
-  _require_dispatch_token ES_REPO_GH_TOKEN "ROR ES" || return $?
+  _require_dispatch_token ROR_GH_TOKEN "ROR ES" || return $?
 
   local WORKFLOW_REF
   WORKFLOW_REF=$(_resolve_workflow_ref "$ROR_ES_PUBLISH_WORKFLOW_REF" "$ROR_ES_GH_REPO" \
-    "$ES_REPO_GH_TOKEN" "$TARGET_BRANCH" "$ROR_ES_PUBLISH_WORKFLOW_FALLBACK_REF")
+    "$ROR_GH_TOKEN" "$TARGET_BRANCH" "$ROR_ES_PUBLISH_WORKFLOW_FALLBACK_REF")
 
   echo ""
   echo ">>> Dispatching ROR ES pre-build: versions=$ES_VERSIONS tag=$RUN_TAG branch=$TARGET_BRANCH${WORKFLOW_REF:+ (workflow ref: $WORKFLOW_REF)}"
@@ -340,7 +340,7 @@ dispatch_es_prebuild_image() {
   # dispatch against that copy, not against the one on WORKFLOW_REF. A mismatch fails with 422
   # "Unexpected inputs provided", listing the names it did not recognise.
   _dispatch_prebuild_workflow "ROR ES" \
-    "$ROR_ES_GH_REPO" "$ROR_ES_PUBLISH_WORKFLOW" "$WORKFLOW_REF" "$ES_REPO_GH_TOKEN" \
+    "$ROR_ES_GH_REPO" "$ROR_ES_PUBLISH_WORKFLOW" "$WORKFLOW_REF" "$ROR_GH_TOKEN" \
     -f "es_versions=$ES_VERSIONS" \
     -f "target_branch=$TARGET_BRANCH" \
     -f "tag=$RUN_TAG" \
@@ -391,7 +391,7 @@ wait_for_prebuild_image() {
       RUN_ID=${ROR_ES_PREBUILD_RUN_ID:-}
       RUN_URL=${ROR_ES_PREBUILD_RUN_URL:-}
       RUN_REPO=$ROR_ES_GH_REPO
-      RUN_TOKEN=${ES_REPO_GH_TOKEN:-}
+      RUN_TOKEN=${ROR_GH_TOKEN:-}
       ;;
     kbn)
       IMAGE=$(ror_kbn_dev_image "$VERSION" "$RUN_TAG")
@@ -400,7 +400,7 @@ wait_for_prebuild_image() {
       RUN_ID=${ROR_KBN_PREBUILD_RUN_ID:-}
       RUN_URL=${ROR_KBN_PREBUILD_RUN_URL:-}
       RUN_REPO=$ROR_KBN_GH_REPO
-      RUN_TOKEN=${KBN_REPO_GH_TOKEN:-}
+      RUN_TOKEN=${ROR_GH_TOKEN:-}
       ;;
     *)
       echo "ERROR: wait_for_prebuild_image: plugin must be 'es' or 'kbn', got '$PLUGIN'"


### PR DESCRIPTION
Part 3 of 3. Companions: `sscarduzio/elasticsearch-readonlyrest-plugin#1347` and `sscarduzio/readonlyrest_kbn#1007`. **All three must merge together** — one Doppler config feeds every repo.

## What changes

| Was | Is |
|---|---|
| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_ENDPOINT_URL` | `ROR_S3_ACCESS_KEY_ID` / `ROR_S3_SECRET_ACCESS_KEY` / `ROR_S3_ENDPOINT_URL` |
| bucket + region hardcoded as action-input defaults | `vars.ROR_S3_BUCKET` / `vars.ROR_S3_REGION` |
| key prefix hardcoded `ror/e2e_reports/build_<run_id>` | `vars.ROR_S3_PATH_E2E_REPORTS` + `/build_<run_id>` |
| `ROR_KBN_LICENSE` | `ROR_ENT_ACTIVATION_TOKEN` |
| `ES_REPO_GH_TOKEN`, `KBN_REPO_GH_TOKEN` | `ROR_GH_TOKEN` |
| `DOCKER_REGISTRY_USER` / `_PASSWORD` | `DOCKER_HUB_USER` / `DOCKER_HUB_RW_TOKEN` |

## Two things worth knowing

**The hardcoded region disagreed with the other repos.** `upload-videos/action.yml` defaulted to `eu-west-1`; ES and kbn sign `us-east-1` for the same bucket. Nobody noticed because the DGP gateway ignores the region entirely — a request signed `xx-fake-9` returns 200. It now comes from a variable like everything else, so the three repos cannot drift again.

**The two dispatch PATs were one token.** `ES_REPO_GH_TOKEN` and `KBN_REPO_GH_TOKEN` held identical values, and that token had `push` on `readonlyrest_kbn` but not on the ES repo — which is why `Prepare dev images` failed with `403 Must have admin rights` when dispatching the ES pre-build. Collapsing them to `ROR_GH_TOKEN` makes the single-credential reality visible instead of implied.

## Deliberately untouched

`ROR_ACTIVATION_KEY` remains the env var name in `environments/**` and `e2e-tests/run-tests.sh` — it is what the ROR Kibana plugin reads and what customers set. Only the secret is renamed.

## Verification done

- Strict duplicate-key YAML parse on both workflows and the composite action.
- `bash -n` on the changed scripts.
- Confirmed `PREFIX_VAR="ROR_S3_PATH_${STORE}"` resolves to `ROR_S3_PATH_E2E_REPORTS` with `STORE=E2E_REPORTS`.

Note `master` and `develop` differ in this repo; this targets `develop` and `master` needs the same change before its nightly runs on the new names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)