### PR TITLE
Use one S3 credential set and consistent CI secret names (master)

### DIFF
--- a/.github/scripts/upload-cypress-artifacts-to-s3.sh
+++ b/.github/scripts/upload-cypress-artifacts-to-s3.sh
@@ -12,7 +12,7 @@
 #
 # Uploads to the E2E_REPORTS store — the bucket's `e2e_reports/` tree, a sibling of the `builds/`
 # (ARTIFACTS) and `libs/` (LIBS) trees. Same env-var family as those, per ci-lib.sh's
-# ROR_<STORE>_STORE_* convention: ROR_E2E_REPORTS_STORE_{ACCESS_KEY_ID,ACCESS_KEY_SECRET,BUCKET,
+# one credential set: ROR_S3_{ACCESS_KEY_ID,SECRET_ACCESS_KEY,BUCKET,
 # REGION,ENDPOINT_URL,PATH_PREFIX}. It gets its own credentials because the gateway authorizes each
 # prefix separately — the publishing creds are 403ed here, and these must not be able to write to
 # the customer-facing builds/ tree.
@@ -28,12 +28,12 @@ STORE=E2E_REPORTS
 # Resolve this store's env vars indirectly, exactly as ci-lib.sh's upload_using_aws_s3_uploader does
 # (that helper takes one file with a guessed mime type; this one walks a tree and passes an explicit
 # mime, so it drives ci/s3-uploader.sh itself rather than going through it).
-AK_VAR="ROR_${STORE}_STORE_ACCESS_KEY_ID"
-SK_VAR="ROR_${STORE}_STORE_ACCESS_KEY_SECRET"
-BUCKET_VAR="ROR_${STORE}_STORE_BUCKET"
-REGION_VAR="ROR_${STORE}_STORE_REGION"
-ENDPOINT_VAR="ROR_${STORE}_STORE_ENDPOINT_URL"
-PREFIX_VAR="ROR_${STORE}_STORE_PATH_PREFIX"
+AK_VAR="ROR_S3_ACCESS_KEY_ID"
+SK_VAR="ROR_S3_SECRET_ACCESS_KEY"
+BUCKET_VAR="ROR_S3_BUCKET"
+REGION_VAR="ROR_S3_REGION"
+ENDPOINT_VAR="ROR_S3_ENDPOINT_URL"
+PREFIX_VAR="ROR_S3_PATH_${STORE}"
 
 require_env() {
   if [ -z "${!1:-}" ]; then

--- a/.github/upload-videos/action.yml
+++ b/.github/upload-videos/action.yml
@@ -3,17 +3,17 @@ description: 'Upload Cypress failure artifacts (videos, screenshots) to an S3 bu
 
 inputs:
   region:
-    description: 'AWS region'
+    description: 'S3 region (the DGP gateway ignores it, but SigV4 must sign with something)'
     required: true
-    default: 'eu-west-1'
   bucket:
     description: 'S3 bucket name'
     required: true
-    default: 'beshu'
   endpoint_url:
     description: 'S3 endpoint URL'
-    required: false
-    default: ''
+    required: true
+  path_prefix:
+    description: 'Key prefix for the e2e reports store'
+    required: true
   access_key_id:
     description: 'AWS access key ID'
     required: true
@@ -31,15 +31,15 @@ runs:
     - name: Upload Cypress artifacts to S3
       shell: bash
       env:
-        ROR_E2E_REPORTS_STORE_ACCESS_KEY_ID: ${{ inputs.access_key_id }}
-        ROR_E2E_REPORTS_STORE_ACCESS_KEY_SECRET: ${{ inputs.secret_access_key }}
-        ROR_E2E_REPORTS_STORE_BUCKET: ${{ inputs.bucket }}
-        ROR_E2E_REPORTS_STORE_REGION: ${{ inputs.region }}
-        ROR_E2E_REPORTS_STORE_ENDPOINT_URL: ${{ inputs.endpoint_url }}
-        ROR_E2E_REPORTS_STORE_PATH_PREFIX: ror/e2e_reports/build_${{ github.run_id }}
+        ROR_S3_ACCESS_KEY_ID: ${{ inputs.access_key_id }}
+        ROR_S3_SECRET_ACCESS_KEY: ${{ inputs.secret_access_key }}
+        ROR_S3_BUCKET: ${{ inputs.bucket }}
+        ROR_S3_REGION: ${{ inputs.region }}
+        ROR_S3_ENDPOINT_URL: ${{ inputs.endpoint_url }}
+        ROR_S3_PATH_E2E_REPORTS: ${{ inputs.path_prefix }}/build_${{ github.run_id }}
         RESULTS_DIR: ${{ inputs.results_dir }}
         S3_SUBFOLDER: ${{ matrix.env }}/${{ matrix.version }}
       run: |
-        echo "::add-mask::${ROR_E2E_REPORTS_STORE_ACCESS_KEY_ID}"
-        echo "::add-mask::${ROR_E2E_REPORTS_STORE_ACCESS_KEY_SECRET}"
+        echo "::add-mask::${ROR_S3_ACCESS_KEY_ID}"
+        echo "::add-mask::${ROR_S3_SECRET_ACCESS_KEY}"
         "$GITHUB_ACTION_PATH/../scripts/upload-cypress-artifacts-to-s3.sh" "$RESULTS_DIR" "$S3_SUBFOLDER"

--- a/.github/workflows/all-e2e-tests.yml
+++ b/.github/workflows/all-e2e-tests.yml
@@ -56,7 +56,7 @@ jobs:
           command: |
             ./runner.sh --run e2e --env ${{ matrix.env }} --elk ${{ matrix.version }}
         env:
-          ROR_ACTIVATION_KEY: ${{ secrets.ROR_KBN_LICENSE }}
+          ROR_ACTIVATION_KEY: ${{ secrets.ROR_ENT_ACTIVATION_TOKEN }}
           ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
       - name: Stop Docker memory monitor
         if: always()
@@ -68,9 +68,12 @@ jobs:
         continue-on-error: true
         uses: ./.github/upload-videos
         with:
-          access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          endpoint_url: ${{ secrets.AWS_ENDPOINT_URL }}
+          access_key_id: ${{ secrets.ROR_S3_ACCESS_KEY_ID }}
+          secret_access_key: ${{ secrets.ROR_S3_SECRET_ACCESS_KEY }}
+          endpoint_url: ${{ vars.ROR_S3_ENDPOINT_URL }}
+          bucket: ${{ vars.ROR_S3_BUCKET }}
+          region: ${{ vars.ROR_S3_REGION }}
+          path_prefix: ${{ vars.ROR_S3_PATH_E2E_REPORTS }}
 
   # ==========================================
   # BOOTSTRAP TESTS
@@ -113,7 +116,7 @@ jobs:
           command: |
             ./runner.sh --run bootstrap --env ${{ matrix.env }} --elk ${{ matrix.version }}
         env:
-          ROR_ACTIVATION_KEY: ${{ secrets.ROR_KBN_LICENSE }}
+          ROR_ACTIVATION_KEY: ${{ secrets.ROR_ENT_ACTIVATION_TOKEN }}
       - name: Stop Docker memory monitor
         if: always()
         uses: ./.github/docker-memory-monitor
@@ -167,7 +170,7 @@ jobs:
           command: |
             ./runner.sh --run e2e --env ${{ matrix.env }} --elk ${{ matrix.version }} --ror-es ${{ env.ROR_ES_VERSION }} --ror-kbn ${{ env.ROR_KBN_VERSION }} --mode ${{ env.MODE }}
         env:
-          ROR_ACTIVATION_KEY: ${{ secrets.ROR_KBN_LICENSE }}
+          ROR_ACTIVATION_KEY: ${{ secrets.ROR_ENT_ACTIVATION_TOKEN }}
 
       - name: Stop Docker memory monitor
         if: always()
@@ -179,6 +182,9 @@ jobs:
         continue-on-error: true
         uses: ./.github/upload-videos
         with:
-          access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          endpoint_url: ${{ secrets.AWS_ENDPOINT_URL }}
+          access_key_id: ${{ secrets.ROR_S3_ACCESS_KEY_ID }}
+          secret_access_key: ${{ secrets.ROR_S3_SECRET_ACCESS_KEY }}
+          endpoint_url: ${{ vars.ROR_S3_ENDPOINT_URL }}
+          bucket: ${{ vars.ROR_S3_BUCKET }}
+          region: ${{ vars.ROR_S3_REGION }}
+          path_prefix: ${{ vars.ROR_S3_PATH_E2E_REPORTS }}

--- a/.github/workflows/targeted-e2e-tests.yml
+++ b/.github/workflows/targeted-e2e-tests.yml
@@ -64,7 +64,7 @@ jobs:
             [ -n "$MODE" ] && PARAMS+=(--mode "$MODE")
             ./runner.sh "${PARAMS[@]}"
         env:
-          ROR_ACTIVATION_KEY: ${{ secrets.ROR_KBN_LICENSE }}
+          ROR_ACTIVATION_KEY: ${{ secrets.ROR_ENT_ACTIVATION_TOKEN }}
           ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
           ENV: ${{ github.event.inputs.env }}
           ELK_VERSION: ${{ github.event.inputs.elk_version }}
@@ -84,6 +84,9 @@ jobs:
         continue-on-error: true
         uses: ./.github/upload-videos
         with:
-          access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          endpoint_url: ${{ secrets.AWS_ENDPOINT_URL }}
+          access_key_id: ${{ secrets.ROR_S3_ACCESS_KEY_ID }}
+          secret_access_key: ${{ secrets.ROR_S3_SECRET_ACCESS_KEY }}
+          endpoint_url: ${{ vars.ROR_S3_ENDPOINT_URL }}
+          bucket: ${{ vars.ROR_S3_BUCKET }}
+          region: ${{ vars.ROR_S3_REGION }}
+          path_prefix: ${{ vars.ROR_S3_PATH_E2E_REPORTS }}


### PR DESCRIPTION
Mirrors the same change already merged to `develop`. Opened separately because `master` and `develop` have diverged substantially — replaying the develop commit onto master conflicts in every changed file, so this is applied to master's own versions rather than cherry-picked.

## What changes

| Was | Is |
|---|---|
| per-store S3 credential families | one set: `ROR_S3_{ACCESS_KEY_ID,SECRET_ACCESS_KEY,BUCKET,REGION,ENDPOINT_URL}` |
| `ROR_*_STORE_PATH_PREFIX` | `ROR_S3_PATH_{ARTIFACTS,LIBS,E2E_REPORTS}` |
| `DOCKER_REGISTRY_USER` / `_PASSWORD` | `DOCKER_HUB_USER` / `DOCKER_HUB_RW_TOKEN` |
| cross-repo GitHub PATs | `ROR_GH_TOKEN` |
| `ROR_ACTIVATION_KEY` (secret) | `ROR_ENT_ACTIVATION_TOKEN` (secret) |

Doppler project `ror_ci` holds both the old and the new names with identical values, so master and develop can carry this independently and neither branch breaks while the other waits.

## Deliberately untouched

**`ROR_ACTIVATION_KEY` remains the environment variable name.** Only the secret is renamed. The shipped plugin reads `process.env.ROR_ACTIVATION_KEY`, customers set it, and the Docker environments pass it through — renaming it would break customer deployments. Same rule for `DOCKER_AUTH_CONFIG`, `GH_TOKEN` and `GITHUB_TOKEN`.

## Verification

- Strict duplicate-key YAML parse on every changed workflow — the ARTIFACTS and LIBS families shared an `env:` block, so a naive rename collides.
- `bash -n` on every changed script.
- Runtime-constructed names were fixed by hand, not by pattern: `ROR_${STORE}_STORE_*` is invisible to a grep, so the store resolution in `ci-lib.sh` and the Cypress uploaders was rewritten to look up a path only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end test workflows to use the current activation credentials.
  * Standardized report video uploads with shared storage settings.
  * Added required storage location and path configuration for uploaded test reports.
  * Updated report paths to include the workflow run identifier.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->