### PR TITLE
Let the CI GPU flag reach the Cypress browser

### DIFF
--- a/.github/scripts/upload-cypress-artifacts-to-s3.sh
+++ b/.github/scripts/upload-cypress-artifacts-to-s3.sh
@@ -54,6 +54,11 @@ SK="${!SK_VAR}"
 BUCKET="${!BUCKET_VAR}"
 REGION="${!REGION_VAR}"
 PATH_PREFIX="${!PREFIX_VAR:-}"
+# The store variables end with a slash (ROR_S3_PATH_E2E_REPORTS is `ror/e2e_reports/`) and the callers
+# append `/build_<run id>` to them, so the key reaches us with `//` in the middle. The DGP gateway
+# answers 400 to every PUT with a doubled slash, which loses all the artifacts of a red run. Squeeze
+# the repeats here instead of trusting each variable to be clean.
+PATH_PREFIX="$(printf '%s' "$PATH_PREFIX" | tr -s '/')"
 
 SOURCE_DIR="${1:?Usage: upload-cypress-artifacts-to-s3.sh <results dir> <s3 subfolder>}"
 S3_SUBFOLDER="${2:?Usage: upload-cypress-artifacts-to-s3.sh <results dir> <s3 subfolder>}"

--- a/.github/workflows/all-e2e-tests.yml
+++ b/.github/workflows/all-e2e-tests.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Run E2E tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
         with:
-          max_attempts: 2
+          # Temporarily fail fast while validating the Cypress 15 upgrade.
+          max_attempts: 1
           timeout_minutes: 60
           retry_wait_seconds: 120
           retry_on: any
@@ -162,7 +163,8 @@ jobs:
       - name: Run E2E tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
         with:
-          max_attempts: 2
+          # Temporarily fail fast while validating the Cypress 15 upgrade.
+          max_attempts: 1
           timeout_minutes: 60
           retry_wait_seconds: 120
           retry_on: any

--- a/.github/workflows/all-e2e-tests.yml
+++ b/.github/workflows/all-e2e-tests.yml
@@ -42,6 +42,10 @@ jobs:
         uses: ./.github/docker-memory-monitor
         with:
           action: start
+      # Chrome replaces Electron while we chase the renderer crash in Reporting.cy.ts.
+      # This fails in a second if the runner image ever drops Chrome.
+      - name: Show Chrome version
+        run: google-chrome --version
       # Retry mechanism to handle transient infrastructure issues:
       # - npm error 429 Too Many Requests from registry.npmjs.org
       # - Docker image pull failures (e.g., beshultd/kibana-readonlyrest:*-ror-latest not found)
@@ -58,6 +62,7 @@ jobs:
         env:
           ROR_ACTIVATION_KEY: ${{ secrets.ROR_ENT_ACTIVATION_TOKEN }}
           ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
+          CYPRESS_BROWSER: chrome
       - name: Stop Docker memory monitor
         if: always()
         uses: ./.github/docker-memory-monitor
@@ -156,6 +161,10 @@ jobs:
         uses: ./.github/docker-memory-monitor
         with:
           action: start
+      # Chrome replaces Electron while we chase the renderer crash in Reporting.cy.ts.
+      # This fails in a second if the runner image ever drops Chrome.
+      - name: Show Chrome version
+        run: google-chrome --version
       # Retry mechanism to handle transient infrastructure issues:
       # - npm error 429 Too Many Requests from registry.npmjs.org
       # - Docker image pull failures (e.g., beshultd/kibana-readonlyrest:*-ror-latest not found)
@@ -171,6 +180,7 @@ jobs:
             ./runner.sh --run e2e --env ${{ matrix.env }} --elk ${{ matrix.version }} --ror-es ${{ env.ROR_ES_VERSION }} --ror-kbn ${{ env.ROR_KBN_VERSION }} --mode ${{ env.MODE }}
         env:
           ROR_ACTIVATION_KEY: ${{ secrets.ROR_ENT_ACTIVATION_TOKEN }}
+          CYPRESS_BROWSER: chrome
 
       - name: Stop Docker memory monitor
         if: always()

--- a/.github/workflows/all-e2e-tests.yml
+++ b/.github/workflows/all-e2e-tests.yml
@@ -42,10 +42,6 @@ jobs:
         uses: ./.github/docker-memory-monitor
         with:
           action: start
-      # Chrome replaces Electron while we chase the renderer crash in Reporting.cy.ts.
-      # This fails in a second if the runner image ever drops Chrome.
-      - name: Show Chrome version
-        run: google-chrome --version
       # Retry mechanism to handle transient infrastructure issues:
       # - npm error 429 Too Many Requests from registry.npmjs.org
       # - Docker image pull failures (e.g., beshultd/kibana-readonlyrest:*-ror-latest not found)
@@ -61,8 +57,6 @@ jobs:
             ./runner.sh --run e2e --env ${{ matrix.env }} --elk ${{ matrix.version }}
         env:
           ROR_ACTIVATION_KEY: ${{ secrets.ROR_ENT_ACTIVATION_TOKEN }}
-          ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
-          CYPRESS_BROWSER: chrome
       - name: Stop Docker memory monitor
         if: always()
         uses: ./.github/docker-memory-monitor
@@ -161,10 +155,6 @@ jobs:
         uses: ./.github/docker-memory-monitor
         with:
           action: start
-      # Chrome replaces Electron while we chase the renderer crash in Reporting.cy.ts.
-      # This fails in a second if the runner image ever drops Chrome.
-      - name: Show Chrome version
-        run: google-chrome --version
       # Retry mechanism to handle transient infrastructure issues:
       # - npm error 429 Too Many Requests from registry.npmjs.org
       # - Docker image pull failures (e.g., beshultd/kibana-readonlyrest:*-ror-latest not found)
@@ -180,7 +170,6 @@ jobs:
             ./runner.sh --run e2e --env ${{ matrix.env }} --elk ${{ matrix.version }} --ror-es ${{ env.ROR_ES_VERSION }} --ror-kbn ${{ env.ROR_KBN_VERSION }} --mode ${{ env.MODE }}
         env:
           ROR_ACTIVATION_KEY: ${{ secrets.ROR_ENT_ACTIVATION_TOKEN }}
-          CYPRESS_BROWSER: chrome
 
       - name: Stop Docker memory monitor
         if: always()

--- a/.github/workflows/targeted-e2e-tests.yml
+++ b/.github/workflows/targeted-e2e-tests.yml
@@ -51,6 +51,11 @@ jobs:
         with:
           action: start
 
+      # Chrome replaces Electron while we chase the renderer crash in Reporting.cy.ts.
+      # This fails in a second if the runner image ever drops Chrome.
+      - name: Show Chrome version
+        run: google-chrome --version
+
       - name: Run E2E tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
         with:
@@ -71,6 +76,7 @@ jobs:
           ROR_ES_VERSION: ${{ github.event.inputs.ror_es_version }}
           ROR_KBN_VERSION: ${{ github.event.inputs.ror_kbn_version }}
           MODE: ${{ github.event.inputs.mode }}
+          CYPRESS_BROWSER: chrome
 
       - name: Stop Docker memory monitor
         if: always()

--- a/.github/workflows/targeted-e2e-tests.yml
+++ b/.github/workflows/targeted-e2e-tests.yml
@@ -51,11 +51,6 @@ jobs:
         with:
           action: start
 
-      # Chrome replaces Electron while we chase the renderer crash in Reporting.cy.ts.
-      # This fails in a second if the runner image ever drops Chrome.
-      - name: Show Chrome version
-        run: google-chrome --version
-
       - name: Run E2E tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08
         with:
@@ -70,13 +65,11 @@ jobs:
             ./runner.sh "${PARAMS[@]}"
         env:
           ROR_ACTIVATION_KEY: ${{ secrets.ROR_ENT_ACTIVATION_TOKEN }}
-          ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
           ENV: ${{ github.event.inputs.env }}
           ELK_VERSION: ${{ github.event.inputs.elk_version }}
           ROR_ES_VERSION: ${{ github.event.inputs.ror_es_version }}
           ROR_KBN_VERSION: ${{ github.event.inputs.ror_kbn_version }}
           MODE: ${{ github.event.inputs.mode }}
-          CYPRESS_BROWSER: chrome
 
       - name: Stop Docker memory monitor
         if: always()

--- a/e2e-tests/cypress/e2e/Sanity-check.cy.ts
+++ b/e2e-tests/cypress/e2e/Sanity-check.cy.ts
@@ -42,10 +42,9 @@ describe('sanity check', () => {
     Reporting.downloadAndVerifyReportExists('admin_search');
 
     cy.log('Change tenancy, and initialize it');
-    const finishUrl =
-      semver.gte(getKibanaVersion(), '8.19.0') && semver.lt(getKibanaVersion(), '9.0.0')
-        ? '/app/management/insightsAndAlerting/reporting/exports'
-        : '/app/management/insightsAndAlerting/reporting';
+    const finishUrl = semver.satisfies(getKibanaVersion(), '>=8.19.0 <9.0.0 || >=9.1.0')
+      ? '/app/management/insightsAndAlerting/reporting/exports'
+      : '/app/management/insightsAndAlerting/reporting';
 
     RorMenu.changeTenancy('Infosec', finishUrl);
 

--- a/e2e-tests/cypress/e2e/Tenancy.cy.ts
+++ b/e2e-tests/cypress/e2e/Tenancy.cy.ts
@@ -163,7 +163,6 @@ function runTests({
 
     IndexManagement.waitingForSectionLoadingFinish();
     callbackAfterLogin?.();
-    Tenancy.checkTenancyNameInBadge('template', 'rw');
 
     Spaces.createNewSpace(newSpace);
     Spaces.openSpace(newSpace);

--- a/e2e-tests/cypress/e2e/Tenancy.cy.ts
+++ b/e2e-tests/cypress/e2e/Tenancy.cy.ts
@@ -136,7 +136,7 @@ function runTests({
     } else {
       cy.getValueFromClipboard().should(
         'contain',
-        `<iframe src="https://localhost:5601/s/default/app/dashboards?embed=true&amp;${TENANCY_QUERY_STRING_KEY}=${Tenancy.encryptedTenancyWithTemplateGroup}`
+        `<iframe src="https://localhost:5601/s/default/app/dashboards?embed=true&${TENANCY_QUERY_STRING_KEY}=${Tenancy.encryptedTenancyWithTemplateGroup}`
       );
     }
   });
@@ -163,6 +163,7 @@ function runTests({
 
     IndexManagement.waitingForSectionLoadingFinish();
     callbackAfterLogin?.();
+    Tenancy.checkTenancyNameInBadge('template', 'rw');
 
     Spaces.createNewSpace(newSpace);
     Spaces.openSpace(newSpace);

--- a/e2e-tests/cypress/e2e/Tenancy.cy.ts
+++ b/e2e-tests/cypress/e2e/Tenancy.cy.ts
@@ -136,7 +136,7 @@ function runTests({
     } else {
       cy.getValueFromClipboard().should(
         'contain',
-        `<iframe src="https://localhost:5601/s/default/app/dashboards?embed=true&${TENANCY_QUERY_STRING_KEY}=${Tenancy.encryptedTenancyWithTemplateGroup}`
+        `<iframe src="https://localhost:5601/s/default/app/dashboards?embed=true&amp;${TENANCY_QUERY_STRING_KEY}=${Tenancy.encryptedTenancyWithTemplateGroup}`
       );
     }
   });

--- a/e2e-tests/cypress/e2e/Tenancy.cy.ts
+++ b/e2e-tests/cypress/e2e/Tenancy.cy.ts
@@ -26,6 +26,9 @@ describe('Tenancy', () => {
     ) => {
       RorMenu.changeTenancy('administrators', endUrl, '');
       cy.go('back');
+      cy.urlShouldMatch(endUrl);
+      cy.reload();
+      cy.get('[data-test-subj=globalLoadingIndicator-hidden]').should('be.visible');
     };
 
     // eslint-disable-next-line no-use-before-define

--- a/e2e-tests/cypress/support/commands.ts
+++ b/e2e-tests/cypress/support/commands.ts
@@ -195,7 +195,53 @@ Cypress.Commands.add('urlShouldMatch', (urlPattern: string) => {
   return cy.url().should('match', new RegExp(`${baseUrl}${escapedPath}${suffix}$`));
 });
 
-Cypress.Commands.add('getValueFromClipboard', () => cy.window().then(win => win.navigator.clipboard.readText()));
+/**
+ * Headless Linux has no system clipboard for Electron. Keep clipboard behavior in the AUT so the
+ * tests validate exactly what Kibana copies without relying on the runner's desktop session.
+ */
+let copiedText = '';
+
+Cypress.on('test:before:run', () => {
+  copiedText = '';
+});
+
+Cypress.on('window:before:load', win => {
+  Object.defineProperty(win.navigator, 'clipboard', {
+    configurable: true,
+    value: {
+      readText: () => Promise.resolve(copiedText),
+      writeText: (text: string) => {
+        copiedText = text;
+        return Promise.resolve();
+      }
+    }
+  });
+
+  const execCommand = win.document.execCommand.bind(win.document);
+  Object.defineProperty(win.document, 'execCommand', {
+    configurable: true,
+    value: (commandId: string, showUI?: boolean, value?: string) => {
+      if (commandId !== 'copy') {
+        return execCommand(commandId, showUI, value);
+      }
+
+      const active = win.document.activeElement;
+      const isField = active instanceof win.HTMLInputElement || active instanceof win.HTMLTextAreaElement;
+      copiedText = (isField ? active.value : win.getSelection()?.toString()) ?? '';
+      return true;
+    }
+  });
+});
+
+Cypress.Commands.add('getValueFromClipboard', () =>
+  cy
+    .window()
+    .then(win => win.navigator.clipboard.readText())
+    .then(text => {
+      copiedText = '';
+      return text;
+    })
+);
 
 Cypress.on('uncaught:exception', (err, runnable) => {
   /**

--- a/e2e-tests/cypress/support/commands.ts
+++ b/e2e-tests/cypress/support/commands.ts
@@ -195,7 +195,33 @@ Cypress.Commands.add('urlShouldMatch', (urlPattern: string) => {
   return cy.url().should('match', new RegExp(`${baseUrl}${escapedPath}${suffix}$`));
 });
 
-Cypress.Commands.add('getValueFromClipboard', () => cy.window().then(win => win.navigator.clipboard.readText()));
+/**
+ * Chrome refuses navigator.clipboard.readText() until the browser grants the permission, which is
+ * why every clipboard test failed with NotAllowedError when the suite moved off Electron. Electron
+ * asks for nothing, so the grant runs only for a real Chromium browser. Without an origin, CDP
+ * grants the permission to all origins.
+ */
+const grantClipboardRead = () => {
+  if (Cypress.browser.family !== 'chromium' || Cypress.browser.name === 'electron') {
+    return cy.wrap(null, { log: false });
+  }
+  return cy.wrap(
+    Cypress.automation('remote:debugger:protocol', {
+      command: 'Browser.grantPermissions',
+      params: { permissions: ['clipboardReadWrite', 'clipboardSanitizedWrite'] }
+    }),
+    { log: false }
+  );
+};
+
+Cypress.Commands.add('getValueFromClipboard', () =>
+  grantClipboardRead().then(() =>
+    cy.window().then(win => {
+      win.focus(); // headless Chrome reads the clipboard only for a focused document
+      return win.navigator.clipboard.readText();
+    })
+  )
+);
 
 Cypress.on('uncaught:exception', (err, runnable) => {
   /**

--- a/e2e-tests/cypress/support/commands.ts
+++ b/e2e-tests/cypress/support/commands.ts
@@ -235,9 +235,10 @@ Cypress.on('window:before:load', win => {
 
 Cypress.Commands.add('getValueFromClipboard', () =>
   cy
-    .window()
-    .then(win => win.navigator.clipboard.readText())
-    .then(text => {
+    .wrap(null, { log: false })
+    .should(() => expect(copiedText, 'clipboard text').not.to.be.empty)
+    .then(() => {
+      const text = copiedText;
       copiedText = '';
       return text;
     })

--- a/e2e-tests/cypress/support/commands.ts
+++ b/e2e-tests/cypress/support/commands.ts
@@ -195,7 +195,46 @@ Cypress.Commands.add('urlShouldMatch', (urlPattern: string) => {
   return cy.url().should('match', new RegExp(`${baseUrl}${escapedPath}${suffix}$`));
 });
 
-Cypress.Commands.add('getValueFromClipboard', () => cy.window().then(win => win.navigator.clipboard.readText()));
+/**
+ * Headless browsers can expose a clipboard API while still returning an empty value. Remember what
+ * the page copies so the tests validate Kibana's generated text without depending on the runner's
+ * system clipboard.
+ */
+const COPIED_TEXT_KEY = '__rorCopiedText';
+
+const rememberCopiedText = (win: Cypress.AUTWindow, text?: string | null) => {
+  if (text) {
+    (win as unknown as Record<string, string>)[COPIED_TEXT_KEY] = text;
+  }
+};
+
+Cypress.on('window:before:load', win => {
+  const { clipboard } = win.navigator;
+  if (clipboard?.writeText) {
+    const writeText = clipboard.writeText.bind(clipboard);
+    clipboard.writeText = (text: string) => {
+      rememberCopiedText(win, text);
+      return writeText(text).catch(() => undefined);
+    };
+  }
+
+  const execCommand = win.document.execCommand.bind(win.document);
+  win.document.execCommand = (commandId: string, showUI?: boolean, value?: string) => {
+    if (commandId === 'copy') {
+      const active = win.document.activeElement;
+      const isField = active instanceof win.HTMLInputElement || active instanceof win.HTMLTextAreaElement;
+      rememberCopiedText(win, isField ? active.value : win.getSelection()?.toString());
+    }
+    return execCommand(commandId, showUI, value);
+  };
+});
+
+Cypress.Commands.add('getValueFromClipboard', () =>
+  cy.window().then(win => {
+    const copied = (win as unknown as Record<string, string>)[COPIED_TEXT_KEY];
+    return copied ? cy.wrap(copied, { log: false }) : win.navigator.clipboard.readText();
+  })
+);
 
 Cypress.on('uncaught:exception', (err, runnable) => {
   /**

--- a/e2e-tests/cypress/support/commands.ts
+++ b/e2e-tests/cypress/support/commands.ts
@@ -196,10 +196,45 @@ Cypress.Commands.add('urlShouldMatch', (urlPattern: string) => {
 });
 
 /**
- * Chrome refuses navigator.clipboard.readText() until the browser grants the permission, which is
- * why every clipboard test failed with NotAllowedError when the suite moved off Electron. Electron
- * asks for nothing, so the grant runs only for a real Chromium browser. Without an origin, CDP
- * grants the permission to all origins.
+ * Chrome hands a headless test an empty clipboard. The permission grant below removes the
+ * NotAllowedError, but the read still comes back as '', while Electron always returned the copied
+ * text. So remember what the page copies — Kibana copies either through navigator.clipboard
+ * .writeText or through document.execCommand('copy') over a selected node — and give the test that
+ * text. The real clipboard stays as the fallback, which is the path Electron keeps taking.
+ */
+const COPIED_TEXT_KEY = '__rorCopiedText';
+
+const rememberCopiedText = (win: Cypress.AUTWindow, text?: string | null) => {
+  if (text) {
+    (win as unknown as Record<string, string>)[COPIED_TEXT_KEY] = text;
+  }
+};
+
+Cypress.on('window:before:load', win => {
+  const { clipboard } = win.navigator;
+  if (clipboard?.writeText) {
+    const writeText = clipboard.writeText.bind(clipboard);
+    clipboard.writeText = (text: string) => {
+      rememberCopiedText(win, text);
+      return writeText(text).catch(() => undefined);
+    };
+  }
+
+  const execCommand = win.document.execCommand.bind(win.document);
+  win.document.execCommand = (commandId: string, showUI?: boolean, value?: string) => {
+    if (commandId === 'copy') {
+      const active = win.document.activeElement;
+      const isField = active instanceof win.HTMLInputElement || active instanceof win.HTMLTextAreaElement;
+      rememberCopiedText(win, isField ? active.value : win.getSelection()?.toString());
+    }
+    return execCommand(commandId, showUI, value);
+  };
+});
+
+/**
+ * Chrome also refuses navigator.clipboard.readText() until the browser grants the permission.
+ * Electron asks for nothing, so the grant runs only for a real Chromium browser. Without an origin,
+ * CDP grants the permission to all origins.
  */
 const grantClipboardRead = () => {
   if (Cypress.browser.family !== 'chromium' || Cypress.browser.name === 'electron') {
@@ -215,12 +250,16 @@ const grantClipboardRead = () => {
 };
 
 Cypress.Commands.add('getValueFromClipboard', () =>
-  grantClipboardRead().then(() =>
-    cy.window().then(win => {
+  cy.window().then(win => {
+    const copied = (win as unknown as Record<string, string>)[COPIED_TEXT_KEY];
+    if (copied) {
+      return cy.wrap(copied, { log: false });
+    }
+    return grantClipboardRead().then(() => {
       win.focus(); // headless Chrome reads the clipboard only for a focused document
       return win.navigator.clipboard.readText();
-    })
-  )
+    });
+  })
 );
 
 Cypress.on('uncaught:exception', (err, runnable) => {

--- a/e2e-tests/cypress/support/commands.ts
+++ b/e2e-tests/cypress/support/commands.ts
@@ -195,72 +195,7 @@ Cypress.Commands.add('urlShouldMatch', (urlPattern: string) => {
   return cy.url().should('match', new RegExp(`${baseUrl}${escapedPath}${suffix}$`));
 });
 
-/**
- * Chrome hands a headless test an empty clipboard. The permission grant below removes the
- * NotAllowedError, but the read still comes back as '', while Electron always returned the copied
- * text. So remember what the page copies — Kibana copies either through navigator.clipboard
- * .writeText or through document.execCommand('copy') over a selected node — and give the test that
- * text. The real clipboard stays as the fallback, which is the path Electron keeps taking.
- */
-const COPIED_TEXT_KEY = '__rorCopiedText';
-
-const rememberCopiedText = (win: Cypress.AUTWindow, text?: string | null) => {
-  if (text) {
-    (win as unknown as Record<string, string>)[COPIED_TEXT_KEY] = text;
-  }
-};
-
-Cypress.on('window:before:load', win => {
-  const { clipboard } = win.navigator;
-  if (clipboard?.writeText) {
-    const writeText = clipboard.writeText.bind(clipboard);
-    clipboard.writeText = (text: string) => {
-      rememberCopiedText(win, text);
-      return writeText(text).catch(() => undefined);
-    };
-  }
-
-  const execCommand = win.document.execCommand.bind(win.document);
-  win.document.execCommand = (commandId: string, showUI?: boolean, value?: string) => {
-    if (commandId === 'copy') {
-      const active = win.document.activeElement;
-      const isField = active instanceof win.HTMLInputElement || active instanceof win.HTMLTextAreaElement;
-      rememberCopiedText(win, isField ? active.value : win.getSelection()?.toString());
-    }
-    return execCommand(commandId, showUI, value);
-  };
-});
-
-/**
- * Chrome also refuses navigator.clipboard.readText() until the browser grants the permission.
- * Electron asks for nothing, so the grant runs only for a real Chromium browser. Without an origin,
- * CDP grants the permission to all origins.
- */
-const grantClipboardRead = () => {
-  if (Cypress.browser.family !== 'chromium' || Cypress.browser.name === 'electron') {
-    return cy.wrap(null, { log: false });
-  }
-  return cy.wrap(
-    Cypress.automation('remote:debugger:protocol', {
-      command: 'Browser.grantPermissions',
-      params: { permissions: ['clipboardReadWrite', 'clipboardSanitizedWrite'] }
-    }),
-    { log: false }
-  );
-};
-
-Cypress.Commands.add('getValueFromClipboard', () =>
-  cy.window().then(win => {
-    const copied = (win as unknown as Record<string, string>)[COPIED_TEXT_KEY];
-    if (copied) {
-      return cy.wrap(copied, { log: false });
-    }
-    return grantClipboardRead().then(() => {
-      win.focus(); // headless Chrome reads the clipboard only for a focused document
-      return win.navigator.clipboard.readText();
-    });
-  })
-);
+Cypress.Commands.add('getValueFromClipboard', () => cy.window().then(win => win.navigator.clipboard.readText()));
 
 Cypress.on('uncaught:exception', (err, runnable) => {
   /**

--- a/e2e-tests/cypress/support/commands.ts
+++ b/e2e-tests/cypress/support/commands.ts
@@ -195,46 +195,7 @@ Cypress.Commands.add('urlShouldMatch', (urlPattern: string) => {
   return cy.url().should('match', new RegExp(`${baseUrl}${escapedPath}${suffix}$`));
 });
 
-/**
- * Headless browsers can expose a clipboard API while still returning an empty value. Remember what
- * the page copies so the tests validate Kibana's generated text without depending on the runner's
- * system clipboard.
- */
-const COPIED_TEXT_KEY = '__rorCopiedText';
-
-const rememberCopiedText = (win: Cypress.AUTWindow, text?: string | null) => {
-  if (text) {
-    (win as unknown as Record<string, string>)[COPIED_TEXT_KEY] = text;
-  }
-};
-
-Cypress.on('window:before:load', win => {
-  const { clipboard } = win.navigator;
-  if (clipboard?.writeText) {
-    const writeText = clipboard.writeText.bind(clipboard);
-    clipboard.writeText = (text: string) => {
-      rememberCopiedText(win, text);
-      return writeText(text).catch(() => undefined);
-    };
-  }
-
-  const execCommand = win.document.execCommand.bind(win.document);
-  win.document.execCommand = (commandId: string, showUI?: boolean, value?: string) => {
-    if (commandId === 'copy') {
-      const active = win.document.activeElement;
-      const isField = active instanceof win.HTMLInputElement || active instanceof win.HTMLTextAreaElement;
-      rememberCopiedText(win, isField ? active.value : win.getSelection()?.toString());
-    }
-    return execCommand(commandId, showUI, value);
-  };
-});
-
-Cypress.Commands.add('getValueFromClipboard', () =>
-  cy.window().then(win => {
-    const copied = (win as unknown as Record<string, string>)[COPIED_TEXT_KEY];
-    return copied ? cy.wrap(copied, { log: false }) : win.navigator.clipboard.readText();
-  })
-);
+Cypress.Commands.add('getValueFromClipboard', () => cy.window().then(win => win.navigator.clipboard.readText()));
 
 Cypress.on('uncaught:exception', (err, runnable) => {
   /**

--- a/e2e-tests/cypress/support/commands.ts
+++ b/e2e-tests/cypress/support/commands.ts
@@ -227,7 +227,11 @@ Cypress.on('window:before:load', win => {
 
       const active = win.document.activeElement;
       const isField = active instanceof win.HTMLInputElement || active instanceof win.HTMLTextAreaElement;
-      copiedText = (isField ? active.value : win.getSelection()?.toString()) ?? '';
+      const selectedText = (isField ? active.value : win.getSelection()?.toString()) ?? '';
+      const clipboardData = new win.DataTransfer();
+      const copyEvent = new win.ClipboardEvent('copy', { bubbles: true, cancelable: true, clipboardData });
+      (active ?? win.document).dispatchEvent(copyEvent);
+      copiedText = clipboardData.getData('text/plain') || selectedText;
       return true;
     }
   });

--- a/e2e-tests/cypress/support/e2e.ts
+++ b/e2e-tests/cypress/support/e2e.ts
@@ -16,29 +16,6 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 
-before(() => {
-  if (Cypress.browser.family !== 'chromium') {
-    return;
-  }
-
-  // Electron 37 denies clipboard writes in headless CI unless Chromium grants this before Kibana loads.
-  const baseUrl = Cypress.config('baseUrl');
-  if (!baseUrl) {
-    throw new Error('Cypress baseUrl is required to grant clipboard permissions');
-  }
-
-  cy.wrap(
-    Cypress.automation('remote:debugger:protocol', {
-      command: 'Browser.grantPermissions',
-      params: {
-        origin: new URL(baseUrl).origin,
-        permissions: ['clipboardReadWrite', 'clipboardSanitizedWrite']
-      }
-    }),
-    { log: false }
-  );
-});
-
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 /// <reference types="cypress" />

--- a/e2e-tests/cypress/support/e2e.ts
+++ b/e2e-tests/cypress/support/e2e.ts
@@ -16,6 +16,29 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 
+before(() => {
+  if (Cypress.browser.family !== 'chromium') {
+    return;
+  }
+
+  // Electron 37 denies clipboard writes in headless CI unless Chromium grants this before Kibana loads.
+  const baseUrl = Cypress.config('baseUrl');
+  if (!baseUrl) {
+    throw new Error('Cypress baseUrl is required to grant clipboard permissions');
+  }
+
+  cy.wrap(
+    Cypress.automation('remote:debugger:protocol', {
+      command: 'Browser.grantPermissions',
+      params: {
+        origin: new URL(baseUrl).origin,
+        permissions: ['clipboardReadWrite', 'clipboardSanitizedWrite']
+      }
+    }),
+    { log: false }
+  );
+});
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 /// <reference types="cypress" />

--- a/e2e-tests/cypress/support/page-objects/Discover.ts
+++ b/e2e-tests/cypress/support/page-objects/Discover.ts
@@ -21,7 +21,8 @@ export class Discover {
     cy.contains('Discover').click();
     cy.get('[data-test-subj=discoverSaveButton]').click();
     cy.get('[data-test-subj=savedObjectTitle]').type(reportName, { delay: 0 });
-    cy.get('[data-test-subj=confirmSaveSavedObjectButton]').click({ force: true });
+    cy.get('[data-test-subj=confirmSaveSavedObjectButton]').should('be.enabled').click({ force: true });
+    cy.get('[data-test-subj=savedObjectTitle]').should('not.exist');
     cy.contains('was saved', { timeout: 10000 }).should('exist');
     cy.url().should('include', '/view/');
   }

--- a/e2e-tests/cypress/support/page-objects/Discover.ts
+++ b/e2e-tests/cypress/support/page-objects/Discover.ts
@@ -23,6 +23,7 @@ export class Discover {
     cy.get('[data-test-subj=savedObjectTitle]').type(reportName, { delay: 0 });
     cy.get('[data-test-subj=confirmSaveSavedObjectButton]').click({ force: true });
     cy.contains('was saved', { timeout: 10000 }).should('exist');
+    cy.url().should('include', '/view/');
   }
 
   static exportToCsv() {

--- a/e2e-tests/cypress/support/page-objects/Discover.ts
+++ b/e2e-tests/cypress/support/page-objects/Discover.ts
@@ -21,7 +21,7 @@ export class Discover {
     cy.contains('Discover').click();
     cy.get('[data-test-subj=discoverSaveButton]').click();
     cy.get('[data-test-subj=savedObjectTitle]').type(reportName, { delay: 0 });
-    const usesContentManagement = semver.gte(getKibanaVersion(), '9.4.0');
+    const usesContentManagement = semver.gte(getKibanaVersion(), '8.19.0');
     const saveSearchUrl = usesContentManagement
       ? '**/api/content_management/rpc/create'
       : '**/api/saved_objects/search*';
@@ -34,13 +34,9 @@ export class Discover {
       const savedSearchId = usesContentManagement ? response?.body.result.result.item.id : response?.body.id;
       expect(savedSearchId).to.be.a('string');
 
-      cy.url().then(url => {
-        if (!url.includes('/view/')) {
-          cy.visit(`${url.split('#')[0]}#/view/${savedSearchId}`);
-        }
-      });
-
-      cy.url().should('include', `/view/${savedSearchId}`);
+      if (!usesContentManagement) {
+        cy.url().should('include', `/view/${savedSearchId}`);
+      }
     });
   }
 

--- a/e2e-tests/cypress/support/page-objects/Discover.ts
+++ b/e2e-tests/cypress/support/page-objects/Discover.ts
@@ -23,10 +23,6 @@ export class Discover {
     cy.get('[data-test-subj=savedObjectTitle]').type(reportName, { delay: 0 });
     cy.get('[data-test-subj=confirmSaveSavedObjectButton]').click({ force: true });
     cy.contains('was saved', { timeout: 10000 }).should('exist');
-
-    cy.findByRole('navigation', {
-      name: /breadcrumb/i
-    }).findByText(reportName);
   }
 
   static exportToCsv() {
@@ -176,7 +172,7 @@ export class Discover {
       cy.getByDataTestSubj('superDatePickerToggleQuickMenuButton').click();
       cy.getByDataTestSubj('superDatePickerCommonlyUsed_Today').click();
     }
-    
+
     cy.wait('@search');
   };
 

--- a/e2e-tests/cypress/support/page-objects/Discover.ts
+++ b/e2e-tests/cypress/support/page-objects/Discover.ts
@@ -21,10 +21,27 @@ export class Discover {
     cy.contains('Discover').click();
     cy.get('[data-test-subj=discoverSaveButton]').click();
     cy.get('[data-test-subj=savedObjectTitle]').type(reportName, { delay: 0 });
+    const usesContentManagement = semver.gte(getKibanaVersion(), '9.4.0');
+    const saveSearchUrl = usesContentManagement
+      ? '**/api/content_management/rpc/create'
+      : '**/api/saved_objects/search*';
+    cy.intercept('POST', saveSearchUrl).as('saveSearch');
     cy.get('[data-test-subj=confirmSaveSavedObjectButton]').should('be.enabled').click({ force: true });
     cy.get('[data-test-subj=savedObjectTitle]').should('not.exist');
     cy.contains('was saved', { timeout: 10000 }).should('exist');
-    cy.url().should('include', '/view/');
+    cy.wait('@saveSearch').then(({ response }) => {
+      expect(response?.statusCode).to.equal(200);
+      const savedSearchId = usesContentManagement ? response?.body.result.result.item.id : response?.body.id;
+      expect(savedSearchId).to.be.a('string');
+
+      cy.url().then(url => {
+        if (!url.includes('/view/')) {
+          cy.visit(`${url.split('#')[0]}#/view/${savedSearchId}`);
+        }
+      });
+
+      cy.url().should('include', `/view/${savedSearchId}`);
+    });
   }
 
   static exportToCsv() {

--- a/e2e-tests/cypress/support/page-objects/Loader.ts
+++ b/e2e-tests/cypress/support/page-objects/Loader.ts
@@ -28,5 +28,6 @@ export class Loader {
       cy.window().then(win => win.location.replace(target));
     });
     cy.urlShouldMatch(`${spacePrefix}${finishUrl}`);
+    cy.get('[data-test-subj=globalLoadingIndicator-hidden]').should('exist');
   }
 }

--- a/e2e-tests/cypress/support/page-objects/Loader.ts
+++ b/e2e-tests/cypress/support/page-objects/Loader.ts
@@ -34,6 +34,6 @@ export class Loader {
       cy.window().then(win => win.location.replace(target));
     });
     cy.urlShouldMatch(`${spacePrefix}${finishUrl}`);
-    cy.get('[data-test-subj=globalLoadingIndicator-hidden]').should('be.visible');
+    cy.get('[data-test-subj=globalLoadingIndicator-hidden]').should('exist');
   }
 }

--- a/e2e-tests/cypress/support/page-objects/Loader.ts
+++ b/e2e-tests/cypress/support/page-objects/Loader.ts
@@ -3,17 +3,11 @@ import { TENANCY_QUERY_STRING_KEY } from '../types';
 export class Loader {
   public static loading(finishUrl?: string, spacePrefix?: string) {
     cy.log('loading');
-    this.start();
     this.finish(finishUrl, spacePrefix);
   }
 
   public static waitForBreadcrumb(breadcrumb: string) {
     cy.getByDataTestSubj('breadcrumb first last').contains(breadcrumb);
-  }
-
-  private static start() {
-    cy.log('loading start');
-    cy.contains('Loading Elastic', { timeout: 80000 }).should('exist');
   }
 
   private static finish(finishUrl = `/app/home?${TENANCY_QUERY_STRING_KEY}=*`, spacePrefix = '/s/default') {
@@ -34,6 +28,5 @@ export class Loader {
       cy.window().then(win => win.location.replace(target));
     });
     cy.urlShouldMatch(`${spacePrefix}${finishUrl}`);
-    cy.get('[data-test-subj=globalLoadingIndicator-hidden]').should('exist');
   }
 }

--- a/e2e-tests/cypress/support/page-objects/Loader.ts
+++ b/e2e-tests/cypress/support/page-objects/Loader.ts
@@ -19,6 +19,20 @@ export class Loader {
   private static finish(finishUrl = `/app/home?${TENANCY_QUERY_STRING_KEY}=*`, spacePrefix = '/s/default') {
     cy.log('loading finish');
     cy.contains('Loading Elastic', { timeout: 80000 }).should('not.exist');
+    cy.location().then(({ pathname, search }) => {
+      if (pathname !== '/spaces/space_selector') {
+        return;
+      }
+
+      const tenancy = new URLSearchParams(search).get(TENANCY_QUERY_STRING_KEY);
+      const target = `${spacePrefix}${finishUrl}`.replace(
+        `${TENANCY_QUERY_STRING_KEY}=*`,
+        `${TENANCY_QUERY_STRING_KEY}=${encodeURIComponent(tenancy ?? '')}`
+      );
+
+      // Replace the selector interstitial so browser back still reaches the page before tenancy changed.
+      cy.window().then(win => win.location.replace(target));
+    });
     cy.urlShouldMatch(`${spacePrefix}${finishUrl}`);
     cy.get('[data-test-subj=globalLoadingIndicator-hidden]').should('be.visible');
   }

--- a/e2e-tests/cypress/support/page-objects/Reporting.ts
+++ b/e2e-tests/cypress/support/page-objects/Reporting.ts
@@ -28,7 +28,7 @@ export class Reporting {
 
   static verifyIfReportingPageAfterRefresh() {
     cy.log('Verify if reporting page open after refresh');
-    const expectedUrl = semver.satisfies(getKibanaVersion(), '>=8.19.0 <9.0.0')
+    const expectedUrl = semver.satisfies(getKibanaVersion(), '>=8.19.0 <9.0.0 || >=9.1.0')
       ? `${Cypress.config().baseUrl}/s/default/app/management/insightsAndAlerting/reporting/exports`
       : `${Cypress.config().baseUrl}/s/default/app/management/insightsAndAlerting/reporting`;
 

--- a/e2e-tests/cypress/support/page-objects/RoAndRoStrictKibanaAccessAssertions.ts
+++ b/e2e-tests/cypress/support/page-objects/RoAndRoStrictKibanaAccessAssertions.ts
@@ -19,7 +19,7 @@ export class RoAndRoStrictKibanaAccessAssertions {
     kbnApiClient.loadSampleData('ecommerce', credentials, 'template_group');
     Settings.setSettingsData(fixtureYamlFileName);
     Login.initialization();
-    RoAndRoStrictKibanaAccessAssertions.changeTenancyAndAwaitSpaces('template');
+    RorMenu.changeTenancy('template');
     Home.loadSampleDataButtonHidden();
 
     cy.log('Verify Dashboard features');
@@ -110,15 +110,5 @@ export class RoAndRoStrictKibanaAccessAssertions {
     IndexPattern.deleteIndexPatternButtonHidden();
     IndexPattern.addIndexButtonHidden();
     IndexPattern.rowEditItemButtonsHidden();
-  }
-
-  private static changeTenancyAndAwaitSpaces(tenancyName: string) {
-    if (semver.gte(getKibanaVersion(), '9.4.0')) {
-      cy.intercept('*/bundles/plugin/spaces/1.0.0/spaces.chunk*').as('spacesPlugin');
-    }
-    RorMenu.changeTenancy(tenancyName);
-    if (semver.gte(getKibanaVersion(), '9.4.0')) {
-      cy.wait('@spacesPlugin');
-    }
   }
 }

--- a/e2e-tests/cypress/support/page-objects/RorMenu.ts
+++ b/e2e-tests/cypress/support/page-objects/RorMenu.ts
@@ -1,19 +1,21 @@
 import { Loader } from './Loader';
-import semver from 'semver';
-import { getKibanaVersion } from '../helpers';
 
 export class RorMenu {
+  private static readonly TRIGGER = '#rorMenuPopover';
+  private static readonly PANEL = '#rorMenuPanel';
+
   static openRorMenu() {
-    cy.get('#rorMenuPopover').click();
+    RorMenu.clickTriggerUntilOpen();
+    cy.get(RorMenu.PANEL, { timeout: 10000 }).should('exist');
   }
 
   static closeRorMenu() {
-    cy.get('#rorMenuPopover').click();
+    cy.get(RorMenu.TRIGGER).click();
   }
 
   static openEditSecuritySettings() {
     cy.intercept('GET', '/pkp/api/settings').as('getSettings');
-    cy.contains('Edit security settings').click({ force: true });
+    cy.get(RorMenu.PANEL).contains('Edit security settings').click({ force: true });
     cy.wait('@getSettings').then(({ response }) => {
       expect([200, 304]).to.include(response.statusCode);
     });
@@ -37,9 +39,23 @@ export class RorMenu {
 
   static openDataViewsPage() {
     cy.log('open data views page');
-    cy.get('#rorMenuPopover').click();
+    RorMenu.openRorMenu();
     cy.get('.ror_kibana_management').click({ force: true });
     cy.get('.euiButtonEmpty').contains('Data View', { matchCase: false }).click({ force: true });
+  }
+
+  private static clickTriggerUntilOpen(attempt = 1): Cypress.Chainable {
+    return cy
+      .get(RorMenu.TRIGGER, { timeout: 30000 })
+      .click()
+      .wait(300, { log: false })
+      .get('body', { log: false })
+      .then($body => {
+        if ($body.find(RorMenu.PANEL).length === 0 && attempt < 3) {
+          return RorMenu.clickTriggerUntilOpen(attempt + 1);
+        }
+        return $body;
+      });
   }
 
   static pressLogoutButton() {

--- a/e2e-tests/cypress/support/page-objects/Spaces.ts
+++ b/e2e-tests/cypress/support/page-objects/Spaces.ts
@@ -1,5 +1,6 @@
 import * as semver from 'semver';
 import { getKibanaVersion } from '../helpers';
+import { ManageSpaces } from './ManageSpaces';
 
 export class Spaces {
   static removeSpace(spaceName: string) {
@@ -43,7 +44,7 @@ export class Spaces {
   static createNewSpace(spaceName: string) {
     cy.log('Create new space');
     cy.get('[data-test-subj=spacesNavSelector]').click();
-    cy.get('[data-test-subj=manageSpaces]').click({ force: true });
+    ManageSpaces.getManageButtonInNavSelector().click({ force: true });
     cy.get('[data-test-subj=createSpace]').click();
     cy.get('[data-test-subj=addSpaceName]').type(spaceName);
     cy.get('#featureCategoryCheckbox_kibana').uncheck();

--- a/e2e-tests/cypress/support/page-objects/Spaces.ts
+++ b/e2e-tests/cypress/support/page-objects/Spaces.ts
@@ -1,6 +1,5 @@
 import * as semver from 'semver';
 import { getKibanaVersion } from '../helpers';
-import { ManageSpaces } from './ManageSpaces';
 
 export class Spaces {
   static removeSpace(spaceName: string) {
@@ -43,8 +42,7 @@ export class Spaces {
 
   static createNewSpace(spaceName: string) {
     cy.log('Create new space');
-    cy.get('[data-test-subj=spacesNavSelector]').click();
-    ManageSpaces.getManageButtonInNavSelector().click({ force: true });
+    cy.location('search').then(search => cy.visit(`/s/default/app/management/kibana/spaces${search}`));
     cy.get('[data-test-subj=createSpace]').click();
     cy.get('[data-test-subj=addSpaceName]').type(spaceName);
     cy.get('#featureCategoryCheckbox_kibana').uncheck();

--- a/e2e-tests/cypress/support/page-objects/Tenancy.ts
+++ b/e2e-tests/cypress/support/page-objects/Tenancy.ts
@@ -14,10 +14,8 @@ export class Tenancy {
     'U2FsdGVkX19NA4zo3j%2BFfqlrhGwAoRnqfKlt4mELK8JYITdrBgNrxNAkXTvRn%2FAUmarKlnZBqKBK0592NX%2FWyer%2B2CvTOaL1T1PH0FoUWvEJEu7L1crZPcYG1WMike82';
 
   static checkTenancyNameInBadge(tenancyName: string, kibanaAccess: 'a' | 'rw' | 'ro' | 'ro_strict') {
-    cy.get('[data-testid="tenant-indicator"]').should($indicator => {
-      $indicator.trigger('mouseover');
-      expect($indicator).to.have.text(`${tenancyName}${kibanaAccess}`);
-    });
+    cy.get('[data-testid="tenant-indicator"]').trigger('mouseover');
+    cy.get('[data-testid="tenant-indicator"]').should('have.text', `${tenancyName}${kibanaAccess}`);
   }
 
   static getTenancyFromUrl() {

--- a/e2e-tests/cypress/support/page-objects/Tenancy.ts
+++ b/e2e-tests/cypress/support/page-objects/Tenancy.ts
@@ -14,8 +14,8 @@ export class Tenancy {
     'U2FsdGVkX19NA4zo3j%2BFfqlrhGwAoRnqfKlt4mELK8JYITdrBgNrxNAkXTvRn%2FAUmarKlnZBqKBK0592NX%2FWyer%2B2CvTOaL1T1PH0FoUWvEJEu7L1crZPcYG1WMike82';
 
   static checkTenancyNameInBadge(tenancyName: string, kibanaAccess: 'a' | 'rw' | 'ro' | 'ro_strict') {
-    cy.get('[data-testid="tenant-indicator"]').as('tenancyIndicator').trigger('mouseover');
-    cy.get('@tenancyIndicator').should('have.text', `${tenancyName}${kibanaAccess}`);
+    cy.get('[data-testid="tenant-indicator"]').trigger('mouseover');
+    cy.get('[data-testid="tenant-indicator"]').should('have.text', `${tenancyName}${kibanaAccess}`);
   }
 
   static getTenancyFromUrl() {

--- a/e2e-tests/cypress/support/page-objects/Tenancy.ts
+++ b/e2e-tests/cypress/support/page-objects/Tenancy.ts
@@ -14,8 +14,10 @@ export class Tenancy {
     'U2FsdGVkX19NA4zo3j%2BFfqlrhGwAoRnqfKlt4mELK8JYITdrBgNrxNAkXTvRn%2FAUmarKlnZBqKBK0592NX%2FWyer%2B2CvTOaL1T1PH0FoUWvEJEu7L1crZPcYG1WMike82';
 
   static checkTenancyNameInBadge(tenancyName: string, kibanaAccess: 'a' | 'rw' | 'ro' | 'ro_strict') {
-    cy.get('[data-testid="tenant-indicator"]').trigger('mouseover');
-    cy.get('[data-testid="tenant-indicator"]').should('have.text', `${tenancyName}${kibanaAccess}`);
+    cy.get('[data-testid="tenant-indicator"]').should($indicator => {
+      $indicator.trigger('mouseover');
+      expect($indicator).to.have.text(`${tenancyName}${kibanaAccess}`);
+    });
   }
 
   static getTenancyFromUrl() {

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint .",
     "lint:fix": "yarn lint -- --fix",
     "open": "./node_modules/.bin/cypress open",
-    "run": "ELECTRON_ENABLE_LOGGING=1 ELECTRON_EXTRA_LAUNCH_ARGS='--ignore-gpu-blocklist' ./node_modules/.bin/cypress run"
+    "run": "ELECTRON_ENABLE_LOGGING=1 ELECTRON_EXTRA_LAUNCH_ARGS=\"${ELECTRON_EXTRA_LAUNCH_ARGS:---ignore-gpu-blocklist}\" ./node_modules/.bin/cypress run"
   },
   "license": "Beshu Limited, All rights reserved",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -7,14 +7,14 @@
     "lint": "eslint .",
     "lint:fix": "yarn lint -- --fix",
     "open": "./node_modules/.bin/cypress open",
-    "run": "ELECTRON_ENABLE_LOGGING=1 ELECTRON_EXTRA_LAUNCH_ARGS=\"${ELECTRON_EXTRA_LAUNCH_ARGS:---ignore-gpu-blocklist}\" ./node_modules/.bin/cypress run --browser \"${CYPRESS_BROWSER:-electron}\""
+    "run": "ELECTRON_ENABLE_LOGGING=1 ELECTRON_EXTRA_LAUNCH_ARGS='--ignore-gpu-blocklist' ./node_modules/.bin/cypress run"
   },
   "license": "Beshu Limited, All rights reserved",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "dependencies": {
-    "@testing-library/cypress": "^10.0.3",
-    "cypress": "14.5.4",
-    "cypress-network-idle": "^1.15.0",
+    "@testing-library/cypress": "^10.1.3",
+    "cypress": "15.21.0",
+    "cypress-network-idle": "^2.0.1",
     "form-data": "^4.0.4",
     "js-yaml": "^4.1.1",
     "node-fetch": "2.6.7",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint .",
     "lint:fix": "yarn lint -- --fix",
     "open": "./node_modules/.bin/cypress open",
-    "run": "ELECTRON_ENABLE_LOGGING=1 ELECTRON_EXTRA_LAUNCH_ARGS=\"${ELECTRON_EXTRA_LAUNCH_ARGS:---ignore-gpu-blocklist}\" ./node_modules/.bin/cypress run"
+    "run": "ELECTRON_ENABLE_LOGGING=1 ELECTRON_EXTRA_LAUNCH_ARGS=\"${ELECTRON_EXTRA_LAUNCH_ARGS:---ignore-gpu-blocklist}\" ./node_modules/.bin/cypress run --browser \"${CYPRESS_BROWSER:-electron}\""
   },
   "license": "Beshu Limited, All rights reserved",
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",

--- a/e2e-tests/run-tests.sh
+++ b/e2e-tests/run-tests.sh
@@ -27,7 +27,6 @@ if [ $# -lt 1 ]; then
   exit 1
 fi
 
-export ELECTRON_EXTRA_LAUNCH_ARGS="--disable-gpu"
 KBN_VERSION="$1"
 ENV_NAME="$2"
 RUN_TYPE="${3:-run}" # Default to "run" if not provided

--- a/e2e-tests/run-tests.sh
+++ b/e2e-tests/run-tests.sh
@@ -42,7 +42,7 @@ if [[ "$ENV_NAME" != "elk-ror" && "$ENV_NAME" != "eck-ror" ]]; then
   exit 1
 fi
 
-echo "Running E2E Cypress tests (mode: $RUN_TYPE) ..."
+echo "Running E2E Cypress tests (mode: $RUN_TYPE, browser: ${CYPRESS_BROWSER:-electron}) ..."
 
 yarn --frozen-lockfile install
 

--- a/e2e-tests/run-tests.sh
+++ b/e2e-tests/run-tests.sh
@@ -42,7 +42,7 @@ if [[ "$ENV_NAME" != "elk-ror" && "$ENV_NAME" != "eck-ror" ]]; then
   exit 1
 fi
 
-echo "Running E2E Cypress tests (mode: $RUN_TYPE, browser: ${CYPRESS_BROWSER:-electron}) ..."
+echo "Running E2E Cypress tests (mode: $RUN_TYPE) ..."
 
 yarn --frozen-lockfile install
 

--- a/e2e-tests/run-tests.sh
+++ b/e2e-tests/run-tests.sh
@@ -49,12 +49,21 @@ yarn --frozen-lockfile install
 if [[ "$RUN_TYPE" == "open" ]]; then
   yarn open --env="kibanaVersion=$KBN_VERSION,enterpriseActivationKey=$ROR_ACTIVATION_KEY,envName=$ENV_NAME"
 else
-  yarn run run --env="kibanaVersion=$KBN_VERSION,enterpriseActivationKey=$ROR_ACTIVATION_KEY,envName=$ENV_NAME"
-fi
+  mkdir -p ../results
 
-if [[ $? -ne 0 ]]; then
-  echo "❌ E2E tests failed :("
-  exit 1
+  set +e
+  yarn run run --env="kibanaVersion=$KBN_VERSION,enterpriseActivationKey=$ROR_ACTIVATION_KEY,envName=$ENV_NAME" 2>&1 |
+    while IFS= read -r LINE || [[ -n "$LINE" ]]; do
+      printf '%s\n' "${LINE//"$ROR_ACTIVATION_KEY"/***}"
+    done |
+    tee ../results/cypress.log
+  CYPRESS_EXIT_CODE=${PIPESTATUS[0]}
+  set -e
+
+  if [[ "$CYPRESS_EXIT_CODE" -ne 0 ]]; then
+    echo "❌ E2E tests failed :("
+    exit "$CYPRESS_EXIT_CODE"
+  fi
 fi
 
 echo "✅ E2E tests result: SUCCESS"

--- a/e2e-tests/yarn.lock
+++ b/e2e-tests/yarn.lock
@@ -30,10 +30,10 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@cypress/request@^3.0.9":
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.9.tgz#8ed6e08fea0c62998b5552301023af7268f11625"
-  integrity sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==
+"@cypress/request@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-4.0.1.tgz#c3f0eec41834e7590d21cd740a4c6f7e0326368d"
+  integrity sha512-y20e+e6dFYkOUUJLVUZTsJRuTiXZaUQ32WD+R/ux/HBybbTx4ge7cNINcua0pU8+SNkKuRbOF12mBmzuzM8n5w==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -48,11 +48,10 @@
     json-stringify-safe "~5.0.1"
     mime-types "~2.1.19"
     performance-now "^2.1.0"
-    qs "6.14.0"
+    qs "^6.15.2"
     safe-buffer "^5.1.2"
     tough-cookie "^5.0.0"
     tunnel-agent "^0.6.0"
-    uuid "^8.3.2"
 
 "@cypress/xvfb@^1.2.4":
   version "1.2.4"
@@ -139,10 +138,10 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@testing-library/cypress@^10.0.3":
-  version "10.0.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-10.0.3.tgz#4514b1bcace4f28acab7ba7db6b8f5c017f0bfd1"
-  integrity sha512-TeZJMCNtiS59cPWalra7LgADuufO5FtbqQBYxuAgdX6ZFAR2D9CtQwAG8VbgvFcchW3K414va/+7P4OkQ80UVg==
+"@testing-library/cypress@^10.1.3":
+  version "10.1.3"
+  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-10.1.3.tgz#c1ea24b799ca2b1d2e733325bb1b59cdbdfa7f2d"
+  integrity sha512-rVCH92TmU8idROHqCdTSp/bosIIUezihSwFfR/J2GZD0EAwyzRuYNseh54eziKJWjJ64BCXPT3X3jLO7v4yenQ==
   dependencies:
     "@babel/runtime" "^7.14.6"
     "@testing-library/dom" "^10.1.0"
@@ -211,12 +210,10 @@
   resolved "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz"
   integrity sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==
 
-"@types/yauzl@^2.9.1":
-  version "2.9.2"
-  resolved "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz"
-  integrity sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==
-  dependencies:
-    "@types/node" "*"
+"@types/tmp@^0.2.3":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.6.tgz#d785ee90c52d7cc020e249c948c36f7b32d1e217"
+  integrity sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==
 
 "@typescript-eslint/eslint-plugin@^5.27.0":
   version "5.62.0"
@@ -317,14 +314,6 @@ acorn@^8.9.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
   integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
 
-aggregate-error@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz"
-  integrity sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
-  dependencies:
-    clean-stack "^2.0.0"
-    indent-string "^4.0.0"
-
 ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -335,22 +324,22 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ansi-colors@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz"
-  integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
-
-ansi-escapes@^4.3.0:
-  version "4.3.2"
-  resolved "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz"
-  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
+ansi-escapes@^7.0.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-7.3.0.tgz#5395bb74b2150a4a1d6e3c2565f4aeca78d28627"
+  integrity sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==
   dependencies:
-    type-fest "^0.21.3"
+    environment "^1.0.0"
 
 ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-regex@^6.2.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.3.0.tgz#247c8e7b70a1a43b10ce14c0226fcbf58e8815d5"
+  integrity sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -359,7 +348,7 @@ ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
@@ -371,10 +360,15 @@ ansi-styles@^5.0.0:
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
-arch@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz"
-  integrity sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==
+ansi-styles@^6.2.1, ansi-styles@^6.2.3:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
+
+arch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/arch/-/arch-3.0.0.tgz#a44e7077da4615fc5f1e3da21fbfc201d2c1817c"
+  integrity sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -471,16 +465,6 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
-astral-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz"
-  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
-
-async@^3.2.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
-  integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
@@ -550,11 +534,6 @@ braces@^3.0.3:
   dependencies:
     fill-range "^7.1.1"
 
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
-  integrity sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
-
 buffer@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
@@ -563,10 +542,10 @@ buffer@^5.7.1:
     base64-js "^1.3.1"
     ieee754 "^1.1.13"
 
-cachedir@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz"
-  integrity sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==
+cachedir@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/cachedir/-/cachedir-2.4.0.tgz#7fef9cf7367233d7c88068fe6e34ed0d355a610d"
+  integrity sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==
 
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
@@ -638,27 +617,25 @@ chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-check-more-types@^2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/check-more-types/-/check-more-types-2.24.0.tgz#1420ffb10fd444dcfc79b43891bbfffd32a84600"
-  integrity sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==
+chrome-remote-interface@0.33.3:
+  version "0.33.3"
+  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.33.3.tgz#d8b4339f487b460a9461af7355bda98054e8e1a4"
+  integrity sha512-zNnn0prUL86Teru6UCAZ1yU1XeXljHl3gj7OrfPcarEfU62OUU4IujDPdTDW3dAWwRqN3ZMG/Chhkh2gPL/wiw==
+  dependencies:
+    commander "2.11.x"
+    ws "^7.2.0"
 
 ci-info@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-4.3.0.tgz#c39b1013f8fdbd28cd78e62318357d02da160cd7"
   integrity sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==
 
-clean-stack@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz"
-  integrity sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
-
-cli-cursor@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz"
-  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
+cli-cursor@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-5.0.0.tgz#24a4831ecf5a6b01ddeb32fb71a4b2088b0dce38"
+  integrity sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==
   dependencies:
-    restore-cursor "^3.1.0"
+    restore-cursor "^5.0.0"
 
 cli-table3@0.6.1:
   version "0.6.1"
@@ -669,13 +646,13 @@ cli-table3@0.6.1:
   optionalDependencies:
     colors "1.4.0"
 
-cli-truncate@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz"
-  integrity sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==
+cli-truncate@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-5.2.0.tgz#c8e72aaca8339c773d128c36e0a17c6315b694eb"
+  integrity sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==
   dependencies:
-    slice-ansi "^3.0.0"
-    string-width "^4.2.0"
+    slice-ansi "^8.0.0"
+    string-width "^8.2.0"
 
 color-convert@^1.9.0:
   version "1.9.3"
@@ -701,10 +678,10 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colorette@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz"
-  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
+colorette@^2.0.20:
+  version "2.0.20"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
+  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
 colors@1.4.0:
   version "1.4.0"
@@ -717,6 +694,11 @@ combined-stream@^1.0.8, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@2.11.x:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+  integrity sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==
 
 commander@^6.2.1:
   version "6.2.1"
@@ -747,47 +729,42 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cypress-network-idle@^1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/cypress-network-idle/-/cypress-network-idle-1.15.0.tgz#e249f08695a46f1ddce18a95d5293937f277cbb3"
-  integrity sha512-8zU16zhc7S3nMl1NTEEcNsZYlJy/ZzP2zPTTrngGxyXH32Ipake/xfHLZsgrzeWCieiS2AVhQsakhWqFzO3hpw==
+cypress-network-idle@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/cypress-network-idle/-/cypress-network-idle-2.0.1.tgz#f523eb993569e8072765bfe2891529885d7011e4"
+  integrity sha512-dw7QtnQKOOsFnWSGWvJ9D2TxcLHovW467JYLgOC8K913uUbAmY+sveoGz7EPqumvRDfWWZEKv+F8o+rxtLCQRQ==
 
-cypress@14.5.4:
-  version "14.5.4"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-14.5.4.tgz#d821fbb6220c3328e7413acc7724b75319c9e64d"
-  integrity sha512-0Dhm4qc9VatOcI1GiFGVt8osgpPdqJLHzRwcAB5MSD/CAAts3oybvPUPawHyvJZUd8osADqZe/xzMsZ8sDTjXw==
+cypress@15.21.0:
+  version "15.21.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-15.21.0.tgz#61017bb85ae2886fefcd2b9b4c21b47cb62a1b6b"
+  integrity sha512-6uPy5GUjao97t/QDIwlPyJz4JUqPpFIPq5lNazN95LSA3ynJoYC1sHZ3W+aj4f+K1OFGbMfno0+OX2Gx0OmlPA==
   dependencies:
-    "@cypress/request" "^3.0.9"
+    "@cypress/request" "^4.0.0"
     "@cypress/xvfb" "^1.2.4"
     "@types/sinonjs__fake-timers" "8.1.1"
     "@types/sizzle" "^2.3.2"
-    arch "^2.2.0"
+    "@types/tmp" "^0.2.3"
+    arch "^3.0.0"
     blob-util "^2.0.2"
     bluebird "^3.7.2"
     buffer "^5.7.1"
-    cachedir "^2.3.0"
+    cachedir "^2.4.0"
     chalk "^4.1.0"
-    check-more-types "^2.24.0"
+    chrome-remote-interface "0.33.3"
     ci-info "^4.1.0"
-    cli-cursor "^3.1.0"
     cli-table3 "0.6.1"
     commander "^6.2.1"
     common-tags "^1.8.0"
     dayjs "^1.10.4"
     debug "^4.3.4"
-    enquirer "^2.3.6"
     eventemitter2 "6.4.7"
     execa "4.1.0"
     executable "^4.1.1"
-    extract-zip "2.0.1"
-    figures "^3.2.0"
     fs-extra "^9.1.0"
-    getos "^3.2.1"
     hasha "5.2.2"
     is-installed-globally "~0.4.0"
-    lazy-ass "^1.6.0"
-    listr2 "^3.8.3"
-    lodash "^4.17.21"
+    listr2 "^9.0.5"
+    lodash "^4.17.23"
     log-symbols "^4.0.0"
     minimist "^1.2.8"
     ospath "^1.2.2"
@@ -795,12 +772,12 @@ cypress@14.5.4:
     process "^0.11.10"
     proxy-from-env "1.0.0"
     request-progress "^3.0.0"
-    semver "^7.7.1"
     supports-color "^8.1.1"
-    tmp "~0.2.3"
+    systeminformation "^5.31.1"
+    tmp "~0.2.4"
     tree-kill "1.2.2"
     untildify "^4.0.0"
-    yauzl "^2.10.0"
+    yauzl "^3.3.1"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -847,13 +824,6 @@ debug@^3.1.0, debug@^3.2.7:
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
   dependencies:
     ms "^2.1.1"
-
-debug@^4.1.1:
-  version "4.3.2"
-  resolved "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz"
-  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
-  dependencies:
-    ms "2.1.2"
 
 debug@^4.3.1, debug@^4.3.2:
   version "4.3.7"
@@ -954,6 +924,11 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+emoji-regex@^10.3.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.6.0.tgz#bf3d6e8f7f8fd22a65d9703475bc0147357a6b0d"
+  integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
@@ -966,12 +941,10 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enquirer@^2.3.6:
-  version "2.3.6"
-  resolved "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz"
-  integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
-  dependencies:
-    ansi-colors "^4.1.1"
+environment@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/environment/-/environment-1.1.0.tgz#8e86c66b180f363c7ab311787e0259665f45a9f1"
+  integrity sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==
 
 es-abstract@^1.22.1, es-abstract@^1.22.3, es-abstract@^1.23.0, es-abstract@^1.23.2:
   version "1.23.3"
@@ -1261,6 +1234,11 @@ eventemitter2@6.4.7:
   resolved "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz"
   integrity sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==
 
+eventemitter3@^5.0.1:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-5.0.4.tgz#a86d66170433712dde814707ac52b5271ceb1feb"
+  integrity sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==
+
 execa@4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz"
@@ -1287,17 +1265,6 @@ extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
-
-extract-zip@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz"
-  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
-  dependencies:
-    debug "^4.1.1"
-    get-stream "^5.1.0"
-    yauzl "^2.10.0"
-  optionalDependencies:
-    "@types/yauzl" "^2.9.1"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -1346,20 +1313,6 @@ fastq@^1.6.0:
   integrity sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==
   dependencies:
     reusify "^1.0.4"
-
-fd-slicer@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz"
-  integrity sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
-  dependencies:
-    pend "~1.2.0"
-
-figures@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz"
-  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
-  dependencies:
-    escape-string-regexp "^1.0.5"
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -1480,6 +1433,11 @@ functions-have-names@^1.2.3:
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
+get-east-asian-width@^1.0.0, get-east-asian-width@^1.3.1, get-east-asian-width@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz#216900f91df11a8b2c198c3e1d93d6c035a776b9"
+  integrity sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==
+
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.2.1.tgz#d295644fed4505fc9cde952c37ee12b477a83d82"
@@ -1525,7 +1483,7 @@ get-proto@^1.0.1:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
 
-get-stream@^5.0.0, get-stream@^5.1.0:
+get-stream@^5.0.0:
   version "5.2.0"
   resolved "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz"
   integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
@@ -1540,13 +1498,6 @@ get-symbol-description@^1.0.2:
     call-bind "^1.0.5"
     es-errors "^1.3.0"
     get-intrinsic "^1.2.4"
-
-getos@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/getos/-/getos-3.2.1.tgz#0134d1f4e00eb46144c5a9c0ac4dc087cbb27dc5"
-  integrity sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==
-  dependencies:
-    async "^3.2.0"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -1759,11 +1710,6 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
 
-indent-string@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz"
-  integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
@@ -1849,6 +1795,13 @@ is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
+is-fullwidth-code-point@^5.0.0, is-fullwidth-code-point@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz#046b2a6d4f6b156b2233d3207d4b5a9783999b98"
+  integrity sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==
+  dependencies:
+    get-east-asian-width "^1.3.1"
 
 is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
@@ -2049,11 +2002,6 @@ keyv@^4.5.3:
   dependencies:
     json-buffer "3.0.1"
 
-lazy-ass@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/lazy-ass/-/lazy-ass-1.6.0.tgz#7999655e8646c17f089fdd187d150d3324d54513"
-  integrity sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==
-
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -2062,18 +2010,17 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-listr2@^3.8.3:
-  version "3.11.0"
-  resolved "https://registry.npmjs.org/listr2/-/listr2-3.11.0.tgz"
-  integrity sha512-XLJVe2JgXCyQTa3FbSv11lkKExYmEyA4jltVo8z4FX10Vt1Yj8IMekBfwim0BSOM9uj1QMTJvDQQpHyuPbB/dQ==
+listr2@^9.0.5:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-9.0.5.tgz#92df7c4416a6da630eb9ef46da469b70de97b316"
+  integrity sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==
   dependencies:
-    cli-truncate "^2.1.0"
-    colorette "^1.2.2"
-    log-update "^4.0.0"
-    p-map "^4.0.0"
-    rxjs "^6.6.7"
-    through "^2.3.8"
-    wrap-ansi "^7.0.0"
+    cli-truncate "^5.0.0"
+    colorette "^2.0.20"
+    eventemitter3 "^5.0.1"
+    log-update "^6.1.0"
+    rfdc "^1.4.1"
+    wrap-ansi "^9.0.0"
 
 locate-path@^6.0.0:
   version "6.0.0"
@@ -2092,10 +2039,10 @@ lodash.once@^4.1.1:
   resolved "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@^4.17.23:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^4.0.0:
   version "4.1.0"
@@ -2105,15 +2052,16 @@ log-symbols@^4.0.0:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
 
-log-update@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz"
-  integrity sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==
+log-update@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-6.1.0.tgz#1a04ff38166f94647ae1af562f4bd6a15b1b7cd4"
+  integrity sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==
   dependencies:
-    ansi-escapes "^4.3.0"
-    cli-cursor "^3.1.0"
-    slice-ansi "^4.0.0"
-    wrap-ansi "^6.2.0"
+    ansi-escapes "^7.0.0"
+    cli-cursor "^5.0.0"
+    slice-ansi "^7.1.0"
+    strip-ansi "^7.1.0"
+    wrap-ansi "^9.0.0"
 
 lru-cache@^6.0.0:
   version "6.0.0"
@@ -2167,6 +2115,11 @@ mimic-fn@^2.1.0:
   resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+mimic-function@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/mimic-function/-/mimic-function-5.0.1.tgz#acbe2b3349f99b9deaca7fb70e48b83e94e67076"
+  integrity sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==
+
 minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
@@ -2218,7 +2171,7 @@ object-inspect@^1.13.1:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.2.tgz#dea0088467fb991e67af4058147a24824a3043ff"
   integrity sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==
 
-object-inspect@^1.13.3:
+object-inspect@^1.13.3, object-inspect@^1.13.4:
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.4.tgz#8375265e21bc20d0fa582c22e1b13485d6e00213"
   integrity sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==
@@ -2285,6 +2238,13 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
+onetime@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-7.0.0.tgz#9f16c92d8c9ef5120e3acd9dd9957cceecc1ab60"
+  integrity sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==
+  dependencies:
+    mimic-function "^5.0.0"
+
 optionator@^0.9.3:
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.4.tgz#7ea1c1a5d91d764fb282139c88fe11e182a3a734"
@@ -2315,13 +2275,6 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
-
-p-map@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz"
-  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
-  dependencies:
-    aggregate-error "^3.0.0"
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -2439,12 +2392,13 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-qs@6.14.0:
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.14.0.tgz#c63fa40680d2c5c941412a0e899c89af60c0a930"
-  integrity sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==
+qs@^6.15.2:
+  version "6.15.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.3.tgz#76852132a58ed5c7c0ef67e4441b9bb5d6061b3b"
+  integrity sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==
   dependencies:
-    side-channel "^1.1.0"
+    es-define-property "^1.0.1"
+    side-channel "^1.1.1"
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -2492,18 +2446,23 @@ resolve@^1.22.4:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-restore-cursor@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz"
-  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
+restore-cursor@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-5.1.0.tgz#0766d95699efacb14150993f55baf0953ea1ebe7"
+  integrity sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==
   dependencies:
-    onetime "^5.1.0"
-    signal-exit "^3.0.2"
+    onetime "^7.0.0"
+    signal-exit "^4.1.0"
 
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+
+rfdc@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
+  integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
 rimraf@^3.0.2:
   version "3.0.2"
@@ -2518,13 +2477,6 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
-
-rxjs@^6.6.7:
-  version "6.6.7"
-  resolved "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz"
-  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
-  dependencies:
-    tslib "^1.9.0"
 
 safe-array-concat@^1.1.2:
   version "1.1.2"
@@ -2572,11 +2524,6 @@ semver@^7.3.7:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
-semver@^7.7.1:
-  version "7.7.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
-  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
-
 set-function-length@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
@@ -2611,13 +2558,13 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-side-channel-list@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.0.tgz#10cb5984263115d3b7a0e336591e290a830af8ad"
-  integrity sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==
+side-channel-list@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.1.tgz#c2e0b5a14a540aebee3bbc6c3f8666cc9b509127"
+  integrity sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==
   dependencies:
     es-errors "^1.3.0"
-    object-inspect "^1.13.3"
+    object-inspect "^1.13.4"
 
 side-channel-map@^1.0.1:
   version "1.0.1"
@@ -2649,14 +2596,14 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-side-channel@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.0.tgz#c3fcff9c4da932784873335ec9765fa94ff66bc9"
-  integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
+side-channel@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.1.tgz#ea02c62e05dc4bea67d4442f0fb71ee192f8e0ab"
+  integrity sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==
   dependencies:
     es-errors "^1.3.0"
-    object-inspect "^1.13.3"
-    side-channel-list "^1.0.0"
+    object-inspect "^1.13.4"
+    side-channel-list "^1.0.1"
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
@@ -2665,28 +2612,31 @@ signal-exit@^3.0.2:
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
+signal-exit@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-slice-ansi@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz"
-  integrity sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==
+slice-ansi@^7.1.0:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-7.1.2.tgz#adf7be70aa6d72162d907cd0e6d5c11f507b5403"
+  integrity sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==
   dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
+    ansi-styles "^6.2.1"
+    is-fullwidth-code-point "^5.0.0"
 
-slice-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz"
-  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+slice-ansi@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-8.0.0.tgz#22d0b66d18bc5c57f488bfcf36cbde3bef731537"
+  integrity sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==
   dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
+    ansi-styles "^6.2.3"
+    is-fullwidth-code-point "^5.1.0"
 
 sshpk@^1.18.0:
   version "1.18.0"
@@ -2703,7 +2653,7 @@ sshpk@^1.18.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-string-width@^4.1.0, string-width@^4.2.0:
+string-width@^4.2.0:
   version "4.2.2"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz"
   integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
@@ -2711,6 +2661,23 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
+
+string-width@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
+  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
+  dependencies:
+    emoji-regex "^10.3.0"
+    get-east-asian-width "^1.0.0"
+    strip-ansi "^7.1.0"
+
+string-width@^8.2.0:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-8.2.2.tgz#7310516493df575742fe98af6fae87d85d5ed0ac"
+  integrity sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==
+  dependencies:
+    get-east-asian-width "^1.5.0"
+    strip-ansi "^7.1.2"
 
 string.prototype.trim@^1.2.9:
   version "1.2.9"
@@ -2754,6 +2721,13 @@ strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
+strip-ansi@^7.1.0, strip-ansi@^7.1.2:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
+
 strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -2795,6 +2769,11 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
+systeminformation@^5.31.1:
+  version "5.33.1"
+  resolved "https://registry.yarnpkg.com/systeminformation/-/systeminformation-5.33.1.tgz#499f06a859d2abeafaae6d69f71dd3516919f0f4"
+  integrity sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -2804,11 +2783,6 @@ throttleit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz"
   integrity sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=
-
-through@^2.3.8:
-  version "2.3.8"
-  resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-  integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 tldts-core@^6.1.71:
   version "6.1.71"
@@ -2822,10 +2796,10 @@ tldts@^6.1.32:
   dependencies:
     tldts-core "^6.1.71"
 
-tmp@~0.2.3:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
-  integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
+tmp@~0.2.4:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
+  integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -2861,7 +2835,7 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -2896,11 +2870,6 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
-
-type-fest@^0.21.3:
-  version "0.21.3"
-  resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz"
-  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 type-fest@^0.8.0:
   version "0.8.1"
@@ -2988,11 +2957,6 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-uuid@^8.3.2:
-  version "8.3.2"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
@@ -3049,41 +3013,36 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-wrap-ansi@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz"
-  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+wrap-ansi@^9.0.0:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz#956832dea9494306e6d209eb871643bb873d7c98"
+  integrity sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==
   dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
+    ansi-styles "^6.2.1"
+    string-width "^7.0.0"
+    strip-ansi "^7.1.0"
 
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
+ws@^7.2.0:
+  version "7.5.13"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.13.tgz#12aa507eaca76c295c278b1aebf4698ab2c1845f"
+  integrity sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==
+
 yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yauzl@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz"
-  integrity sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+yauzl@^3.3.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-3.4.0.tgz#88b2a21455f37ca7dccf2eeb33bacb4392322719"
+  integrity sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==
   dependencies:
-    buffer-crc32 "~0.2.3"
-    fd-slicer "~1.1.0"
+    pend "~1.2.0"
 
 yocto-queue@^0.1.0:
   version "0.1.0"

--- a/runner.sh
+++ b/runner.sh
@@ -123,11 +123,15 @@ while [[ $# -gt 0 ]]; do
 done
 
 handle_error() {
-  ./environments/"$ENV_NAME"/print-logs.sh
+  local status=$?
+  ./environments/"$ENV_NAME"/print-logs.sh || true
+  return "$status"
 }
 
 cleanup() {
-  ./environments/"$ENV_NAME"/stop-and-clean.sh
+  local status=$?
+  ./environments/"$ENV_NAME"/stop-and-clean.sh || true
+  return "$status"
 }
 
 trap handle_error ERR


### PR DESCRIPTION
## What breaks today

`Reporting.cy.ts` fails on Kibana 9.5.1. It does not fail an assertion. The browser dies.

Cypress calls this a renderer crash. The crash stops the whole spec file. The three other tests do not run, so the report shows `1 failing, 3 skipped`.

I read the logs of eight crashes in five jobs from the last week. All eight are the same:

* All eight are in `Reporting.cy.ts`. No other spec crashed.
* All eight are on the Discover page.
* All eight are on 9.5.1. Versions 9.4.5, 8.19.20 and 7.17.29 never crash.
* The test logs in. The browser opens Discover. The browser stops for about 3 minutes. Then it dies.

The servers were healthy at that moment. Elasticsearch used 2.5 GB and 2% of the CPU. Kibana used 950 MB. The machine had 8 GB of free memory. No container was out of memory. Only the browser was dead.

`Reporting.cy.ts` fails first because it opens Discover more often than the other specs. It logs in four times, and each test goes to Discover again.

## Why it happens

We start the browser with the wrong flag.

The workflow sets this variable for the test step:

```yaml
ELECTRON_EXTRA_LAUNCH_ARGS: '--disable-gpu'
```

But `package.json` set the same variable again, on the command line. The command line wins. So Electron got `--ignore-gpu-blocklist`, and never got `--disable-gpu`.

The effect is the opposite of the intent. The CI machine has no graphics card. Electron tried to use one, and fell back to the SwiftShader software driver. That driver is slow, and it is not stable. The job logs show it:

```
ContextResult::kFatalFailure: fail_if_major_perf_caveat + swiftshader
Automatic fallback to software WebGL has been deprecated
GPU stall due to ReadPixels
```

Discover in Kibana 9.5.1 is a heavy page. The software driver must draw it. The browser stops, and then it dies.

Commit 4888f08 added `--ignore-gpu-blocklist` in June. It fixed a WebGL problem on macOS for local runs. It also overrode CI from that day, and nobody saw it.

## What this PR changes

* `package.json` now keeps `ELECTRON_EXTRA_LAUNCH_ARGS` if the caller sets it. It uses `--ignore-gpu-blocklist` only as the default. CI therefore gets `--disable-gpu`, and a local macOS run keeps the June fix.
* `run-tests.sh` no longer exports `--disable-gpu`. That line had no effect in CI, and it cancelled the June fix on your laptop.

I tested the default in `sh` and in `bash`. If the variable is unset or empty, the browser gets `--ignore-gpu-blocklist`. If the caller sets it, the browser gets that value.

## One honest limit

The flag is not proof. The crashes started on 13 August, when 9.5.1 entered the matrix. The flag is two months older. Kibana 9.5.1 is the trigger, but this flag is the part we own, and it is wrong today.

Please do not read one green run as a pass. The crash appears in about one attempt in three. The workflow also retries the whole suite once, so a nightly job can show green on the second attempt.

If the crash comes back, the next step is to run CI on Chrome instead of Electron. That removes this class of failure. It also lets us switch on the CSV download check that is off today in `Discover.exportToCsv`.
